### PR TITLE
Add typed variable assignments

### DIFF
--- a/core/src/interpreter/env.rs
+++ b/core/src/interpreter/env.rs
@@ -148,7 +148,8 @@ impl<'a> Environment<'a> {
             Err(RuntimeError::new(
                 format!("Variable {} already exists", name.clone().yellow()),
                 info.clone(),
-            ))
+            )
+            .with_label("This is defined somewhere else".to_string(), info.clone()))
         } else {
             match value {
                 Value::Function(func) => {

--- a/core/src/interpreter/tests.rs
+++ b/core/src/interpreter/tests.rs
@@ -7,7 +7,6 @@ mod tests {
             number::{FloatingPoint, Number, UnsignedInteger},
             value::Value,
         },
-        util::error::LineInfo,
         parser::parser::{self, ParseResult, ParseResults},
         stdlib::init::{stdlib, Initializer},
         type_checker::{
@@ -15,6 +14,7 @@ mod tests {
             checker::TypeChecker,
             types::{std_types, GetType, Type, TypeTrait},
         },
+        util::error::LineInfo,
     };
 
     fn parse_str_one(expr: &str, std: Option<&Initializer>) -> ParseResult {
@@ -193,16 +193,14 @@ mod tests {
     #[test]
     fn assignment() {
         let ast = CheckedAst::Assignment {
-            target: Box::new(CheckedAst::Identifier {
-                name: "x".to_string(),
-                ty: std_types::UINT8,
+            target: crate::type_checker::checked_ast::CheckedBindPattern::Variable {
+                name: "x".into(),
                 info: LineInfo::default(),
-            }),
+            },
             expr: Box::new(CheckedAst::Literal {
                 value: make_u8(1),
                 info: LineInfo::default(),
             }),
-            ty: std_types::UINT8,
             info: LineInfo::default(),
         };
         let result = eval_expr(&ast, &mut std_env());

--- a/core/src/lexer/error.rs
+++ b/core/src/lexer/error.rs
@@ -38,6 +38,10 @@ impl BaseErrorExt for LexerError {
 }
 
 impl LexerError {
+    pub fn is_eof_error(&self) -> bool {
+        self.inner.info.end.eof
+    }
+
     pub fn unexpected_end_of_file(info: LineInfo) -> Self {
         Self::new("Unexpected end of program".to_string(), info)
     }

--- a/core/src/lexer/tests.rs
+++ b/core/src/lexer/tests.rs
@@ -130,11 +130,10 @@ mod tests {
 
     #[test]
     fn keywords() {
-        let mut lexer = from_str("true false let");
+        let mut lexer = from_str("true false");
         stdlib().init_lexer(&mut lexer);
         assert_next_token_eq(&mut lexer, TokenKind::Boolean(true));
         assert_next_token_eq(&mut lexer, TokenKind::Boolean(false));
-        assert_next_token_eq(&mut lexer, TokenKind::Let);
         assert_next_token_eq(&mut lexer, TokenKind::EndOfFile);
     }
 

--- a/core/src/lexer/token.rs
+++ b/core/src/lexer/token.rs
@@ -31,8 +31,6 @@ pub enum TokenKind {
     // All other operators will be implemented in a standard library at runtime in the future
     // leaving support for user-defined operators
     Op(String),
-    // Keywords
-    Let,
     // Comments
     Comment(String),
 }
@@ -115,7 +113,6 @@ impl Display for TokenKind {
             Self::LeftBracket => write!(f, "["),
             Self::RightBracket => write!(f, "]"),
             Self::Op(s) => write!(f, "{}", s),
-            Self::Let => write!(f, "let"),
             Self::Comment(s) => write!(f, "// {}", s),
         }
     }

--- a/core/src/parser/parser.rs
+++ b/core/src/parser/parser.rs
@@ -722,6 +722,12 @@ impl<R: Read> Parser<R> {
     //     })
     // }
 
+    /// Parses a typed definition, such as a variable assignment with a type annotation.
+    /// 
+    /// # Parameters
+    /// - `annotation`: The type annotation for the definition.
+    /// - `nt`: The current token being processed.
+    /// - `skip`: The number of tokens to skip when peeking into the lexer to check for an assignment operator.
     fn parse_typed_def(
         &mut self,
         annotation: TypeAst,

--- a/core/src/parser/parser.rs
+++ b/core/src/parser/parser.rs
@@ -751,8 +751,15 @@ impl<R: Read> Parser<R> {
                 for _ in 0..skip {
                     self.lexer.next_token().unwrap();
                 }
+
+                //? From now we are sure that we are parsing an assignment!
+                //? No more peeking! Only consume and assert tokens!
+
                 // Parse the assignment expression
-                let expr = self.parse_top_expr().ok()?;
+                let expr = match self.parse_top_expr() {
+                    Ok(expr) => expr,
+                    Err(err) => return Some(Err(err)),
+                };
 
                 log::trace!("Parsed assignment: {:?} = {:?}", &name, &expr);
 

--- a/core/src/parser/tests.rs
+++ b/core/src/parser/tests.rs
@@ -152,7 +152,7 @@ mod tests {
 
     #[test]
     fn tuple_addition() {
-        let result = parse_str_one("(1, 2) + (3, 4)", None);
+        let result = parse_str_one("(1, 2) + (3, 4)", Some(&stdlib()));
         assert!(result.is_ok());
         let result = result.unwrap();
 
@@ -188,10 +188,10 @@ mod tests {
 
     #[test]
     fn call_paren_apply() {
-        let result = parse_str_one("println(\"Hello, World!\")", None);
+        let result = parse_str_one("print(\"Hello, World!\")", Some(&stdlib()));
         let expected = Ast::FunctionCall {
             expr: Box::new(Ast::Identifier {
-                name: "println".to_string(),
+                name: "print".to_string(),
                 info: LineInfo::default(),
             }),
             arg: Box::new(lit(Value::String("Hello, World!".to_string()))),
@@ -205,10 +205,10 @@ mod tests {
 
     #[test]
     fn call_no_paren_apply() {
-        let result = parse_str_one("println \"Hello, World!\"", None);
+        let result = parse_str_one("print \"Hello, World!\"", Some(&stdlib()));
         let expected = Ast::FunctionCall {
             expr: Box::new(Ast::Identifier {
-                name: "println".to_string(),
+                name: "print".to_string(),
                 info: LineInfo::default(),
             }),
             arg: Box::new(lit(Value::String("Hello, World!".to_string()))),
@@ -239,10 +239,13 @@ mod tests {
 
     #[test]
     fn hello_world_file() {
-        let result = parse_str_one(include_str!("../../../examples/basic/hello_world.lt"), None);
+        let result = parse_str_all(
+            include_str!("../../../examples/basic/hello_world.lt"),
+            Some(&stdlib()),
+        );
         let expected = Ast::FunctionCall {
             expr: Box::new(Ast::Identifier {
-                name: "println".to_string(),
+                name: "print".to_string(),
                 info: LineInfo::default(),
             }),
             arg: Box::new(lit(Value::String("Hello, World!".to_string()))),
@@ -250,13 +253,16 @@ mod tests {
         };
         assert!(result.is_ok());
         let result = result.unwrap();
-
-        assert!(result == expected);
+        assert!(result.len() == 3);
+        // All three should be the same
+        assert!(result[0] == expected);
+        assert!(result[1] == expected);
+        assert!(result[2] == expected);
     }
 
     #[test]
     fn arithmetic() {
-        let result = parse_str_one("1 + 2", None);
+        let result = parse_str_one("1 + 2", Some(&stdlib()));
         assert!(result.is_ok());
         let result = result.unwrap();
 
@@ -286,7 +292,7 @@ mod tests {
 
     #[test]
     fn arithmetic_tree() {
-        let result = parse_str_one("1 + 2 + 3", None);
+        let result = parse_str_one("1 + 2 + 3", Some(&stdlib()));
         assert!(result.is_ok());
         let result = result.unwrap();
 
@@ -300,7 +306,7 @@ mod tests {
 
     #[test]
     fn literal_type_identifier() {
-        let result = parse_str_one("int", None);
+        let result = parse_str_one("int", Some(&stdlib()));
         assert!(result.is_ok());
         let result = result.unwrap();
         assert!(matches!(result, Ast::LiteralType { .. }));
@@ -315,10 +321,10 @@ mod tests {
 
     #[test]
     fn typed_assignment() {
-        let result = parse_str_one("int x = 1", None);
+        let result = parse_str_one("int x = 1", Some(&stdlib()));
         assert!(result.is_ok());
         let result = result.unwrap();
-        println!("result: {:?}", result.print_sexpr());
+        println!("result: {:?}", result);
 
         assert!(matches!(result, Ast::Assignment { .. }));
         if let Ast::Assignment {
@@ -347,18 +353,20 @@ mod tests {
 
     #[test]
     fn untyped_assignment() {
-        let result = parse_str_one("x = 1", None);
+        let result = parse_str_one("x = 1", Some(&stdlib()));
         assert!(result.is_ok());
         let result = result.unwrap();
+        println!("result: {:?}", result);
 
         assert!(matches!(result, Ast::Assignment { .. }));
     }
 
     #[test]
     fn assign_add() {
-        let result = parse_str_one("x = 1 + 2", None);
+        let result = parse_str_one("x = 1 + 2", Some(&stdlib()));
         assert!(result.is_ok());
         let result = result.unwrap();
+        println!("result: {:?}", result);
 
         assert!(matches!(result, Ast::Assignment { .. }));
         if let Ast::Assignment { target, expr, .. } = &result {
@@ -372,7 +380,8 @@ mod tests {
         let result = parse_str_all("1; // This is a comment", None);
         assert!(result.is_ok());
         let result = result.unwrap();
-
+        assert!(result.len() == 1);
+        assert!(matches!(result[0], Ast::Literal { .. }));
         assert!(result[0] == lit(make_u1(1)));
     }
 
@@ -504,7 +513,7 @@ mod tests {
 
     #[test]
     fn record_nested_block() {
-        let result = parse_str_one("{ x: { 1 + 2 } }", None);
+        let result = parse_str_one("{ x: { 1 + 2 } }", Some(&stdlib()));
         assert!(result.is_ok());
         let result = result.unwrap();
 

--- a/core/src/stdlib/init.rs
+++ b/core/src/stdlib/init.rs
@@ -53,8 +53,9 @@ impl Initializer {
 
     pub fn init_parser(&self, parser: &mut Parser<impl Read>) {
         log::trace!(
-            "Initializing parser with {} operators",
-            self.operators.len()
+            "Initializing parser with {} operators and {} types",
+            self.operators.len(),
+            self.types.len()
         );
         for op in &self.operators {
             if let Err(e) = parser.define_op(op.info.clone()) {
@@ -62,6 +63,13 @@ impl Initializer {
                     "Parser initialization failed when adding operator '{:?}': {:?}",
                     op, e
                 );
+            }
+        }
+        for ty in self.types.values() {
+            match ty {
+                Type::Literal(ref name) => parser.add_type(name.to_string()),
+                Type::Alias(ref name, _) => parser.add_type(name.to_string()),
+                _ => panic!("Expected literal or alias type but got {:?}", ty),
             }
         }
     }

--- a/core/src/type_checker/checked_ast.rs
+++ b/core/src/type_checker/checked_ast.rs
@@ -478,22 +478,22 @@ impl CheckedBindPattern {
         }
     }
 
-    pub fn specialize(&mut self, judgements: &TypeJudgements, changed: &mut bool) {
+    pub fn specialize(&mut self, _judgements: &TypeJudgements, _changed: &mut bool) {
         match self {
             CheckedBindPattern::Variable { name: _, info: _ } => (),
             CheckedBindPattern::Tuple { elements, info: _ } => {
                 for element in elements {
-                    element.specialize(judgements, changed);
+                    element.specialize(_judgements, _changed);
                 }
             }
             CheckedBindPattern::Record { fields, info: _ } => {
                 for (_, element) in fields {
-                    element.specialize(judgements, changed);
+                    element.specialize(_judgements, _changed);
                 }
             }
             CheckedBindPattern::List { elements, info: _ } => {
                 for element in elements {
-                    element.specialize(judgements, changed);
+                    element.specialize(_judgements, _changed);
                 }
             }
             CheckedBindPattern::Wildcard => (),

--- a/core/src/type_checker/checker.rs
+++ b/core/src/type_checker/checker.rs
@@ -679,7 +679,6 @@ impl TypeChecker<'_> {
                 info: target.info().clone(),
             },
             expr: Box::new(expr),
-            // ty: body_ty,
             info: assign_info,
         })
     }

--- a/core/src/type_checker/checker.rs
+++ b/core/src/type_checker/checker.rs
@@ -649,23 +649,21 @@ impl TypeChecker<'_> {
         let body_ty = expr.get_type().clone();
         if let Some(ann) = annotation {
             let ann_ty = self.check_type_expr(ann)?;
-            if !ann_ty.subtype(&body_ty).success {
+            if !body_ty.subtype(&ann_ty).success {
                 return Err(TypeError::new(
                     format!(
-						"Type annotation {} does not match the type of the expression {}. Expected {}, found {}",
-						ann_ty.pretty_print_color(),
-						expr.pretty_print(),
-						ann_ty.pretty_print_color(),
-						body_ty.pretty_print_color()
-					),
+                        "{} is not a valid subtype of {}",
+                        expr.pretty_print(),
+                        ann_ty.pretty_print_color(),
+                    ),
                     info.clone(),
                 )
                 .with_label(
-                    "Type annotation does not match the expression".to_string(),
-                    ann.info().clone(),
-                )
-                .with_label(
-                    format!("This is of type {}", body_ty.pretty_print_color()),
+                    format!(
+                        "This should be of type {} but is {}",
+                        ann_ty.pretty_print_color(),
+                        body_ty.pretty_print_color()
+                    ),
                     expr.info().clone(),
                 )
                 .into());

--- a/core/src/type_checker/checker.rs
+++ b/core/src/type_checker/checker.rs
@@ -615,7 +615,7 @@ impl TypeChecker<'_> {
         expr: &Ast,
         info: &LineInfo,
     ) -> TypeResult<CheckedAst> {
-        let target = match target {
+        let target_name = match target {
             Ast::Identifier { name, .. } => name,
             _ => {
                 return Err(TypeError::new(
@@ -630,14 +630,18 @@ impl TypeChecker<'_> {
                 .into());
             }
         };
-        if let Some(existing) = self.lookup_local_identifier(target) {
+        if let Some(existing) = self.lookup_local_identifier(target_name) {
             let ty_name = match existing {
                 IdentifierType::Variable(_) => "Variable",
                 IdentifierType::Type(_) => "Type",
                 IdentifierType::Function(_) => "Function",
             };
             return Err(TypeError::new(
-                format!("{} {} already exists", ty_name, target.clone().yellow()),
+                format!(
+                    "{} {} already exists",
+                    ty_name,
+                    target_name.clone().yellow()
+                ),
                 info.clone(),
             )
             .with_hint("Use a different name for the variable".to_string())
@@ -668,11 +672,11 @@ impl TypeChecker<'_> {
             }
         }
         let assign_info = info.join(expr.info());
-        self.env.add_variable(target, body_ty.clone());
+        self.env.add_variable(target_name, body_ty.clone());
         Ok(CheckedAst::Assignment {
             target: CheckedBindPattern::Variable {
-                name: target.to_string(),
-                info: info.clone(),
+                name: target_name.to_string(),
+                info: target.info().clone(),
             },
             expr: Box::new(expr),
             // ty: body_ty,


### PR DESCRIPTION
This pull request introduces several significant changes across different parts of the codebase, focusing on improving functionality, simplifying structures, and removing unused features. The most notable updates include enhancements to the lexer and parser, updates to the type system, and changes to operator handling.

### Lexer Improvements:
* Added a new method `is_eof_error` to the `LexerError` class to identify end-of-file errors more efficiently. (`core/src/lexer/error.rs`)
* Modified `peek_token_not` in the `Lexer` to support skipping a specified number of tokens, with optimizations for EOF handling. (`core/src/lexer/lexer.rs`)
* Removed the `let` keyword from the lexer and associated tests, simplifying the token set. (`core/src/lexer/lexer.rs`, `core/src/lexer/tests.rs`, `core/src/lexer/token.rs`) [[1]](diffhunk://#diff-aa8654414150e4c52f54fc7813ae6030689d7e84b42726f3ed1b5cb9d987430fL1097) [[2]](diffhunk://#diff-31e9202129a6c14b061fd915874d83ba5c45a1a32c63ba6a5e22f27a8d341b13L133-L137) [[3]](diffhunk://#diff-0251de67525e45a3a5647e7c7c998835fb8d43c73451cfedeece29a43e8ce554L34-L35)

### Parser Enhancements:
* Introduced a new `LiteralType` variant to the `Ast` enum, allowing the representation of literal type expressions. (`core/src/parser/ast.rs`) [[1]](diffhunk://#diff-c645a19806a36cab318b626bd9a2d87551794d975e55b5a14609608f2ad9f5d6R80-R84) [[2]](diffhunk://#diff-c645a19806a36cab318b626bd9a2d87551794d975e55b5a14609608f2ad9f5d6R158) [[3]](diffhunk://#diff-c645a19806a36cab318b626bd9a2d87551794d975e55b5a14609608f2ad9f5d6R180)
* Added support for parse-time operators (`ParseOperatorHandler`) to the operator system, enabling macro-like behavior during parsing. (`core/src/parser/op.rs`) [[1]](diffhunk://#diff-79c938c231729c0daaecc1ed00f7943f9759a218c48bd972e7515afc069b3217R180-R181) [[2]](diffhunk://#diff-79c938c231729c0daaecc1ed00f7943f9759a218c48bd972e7515afc069b3217R192-R193) [[3]](diffhunk://#diff-79c938c231729c0daaecc1ed00f7943f9759a218c48bd972e7515afc069b3217L265-R290)
* Updated the `Parser` to manage a set of known types (`types`) and enhanced operator handling to include the new parse-time operators. (`core/src/parser/parser.rs`) [[1]](diffhunk://#diff-1705a701a57e019c136557c9905b05dd8a761e90108d7e28ca6f92408121ec39L73-R85) [[2]](diffhunk://#diff-1705a701a57e019c136557c9905b05dd8a761e90108d7e28ca6f92408121ec39L100-R145)

### Type System Updates:
* Refactored `TypeAst::Identifier` to use a struct-like variant with named fields and added a new `Constructor` variant for type constructors. (`core/src/parser/ast.rs`)

### Interpreter Changes:
* Updated the interpreter to handle the new `LiteralType` in `CheckedAst`. (`core/src/interpreter/eval.rs`)
* Replaced `CheckedAst::Identifier` with `CheckedBindPattern::Variable` in assignment handling, aligning with type-checking changes. (`core/src/interpreter/eval.rs`, `core/src/interpreter/tests.rs`) [[1]](diffhunk://#diff-7a366197d854807b059e127c2f838e834565bc766b47b0e99e30f3a7dfd99004R43-R52) [[2]](diffhunk://#diff-88d9eeef1cfade64832aed6aef41fc4bfdf4258941e73e31c3c51b8403f3e8aeL196-L205)

### Miscellaneous:
* Removed the unused `is_static` field from `OperatorInfo`, simplifying operator metadata. (`core/src/parser/op.rs`)
* Improved error handling in the lexer by adding a fallback for unknown operators. (`core/src/lexer/lexer.rs`)