### PR TITLE
Remove fixed-size numeric types from stdlib

### DIFF
--- a/lentoc/lib/src/stdlib/init.rs
+++ b/lentoc/lib/src/stdlib/init.rs
@@ -243,22 +243,6 @@ pub fn stdlib() -> Initializer {
             }
         })
         .chain([
-            ("u1".into(), std_types::UINT1),
-            ("u8".into(), std_types::UINT8),
-            ("u16".into(), std_types::UINT16),
-            ("u32".into(), std_types::UINT32),
-            ("u64".into(), std_types::UINT64),
-            ("u128".into(), std_types::UINT128),
-            ("ubig".into(), std_types::UINTBIG),
-            ("i8".into(), std_types::INT8),
-            ("i16".into(), std_types::INT16),
-            ("i32".into(), std_types::INT32),
-            ("i64".into(), std_types::INT64),
-            ("i128".into(), std_types::INT128),
-            ("ibig".into(), std_types::INTBIG),
-            ("f32".into(), std_types::FLOAT32),
-            ("f64".into(), std_types::FLOAT64),
-            ("fbig".into(), std_types::FLOATBIG),
             ("uint".into(), std_types::UINT()),
             ("int".into(), std_types::INT()),
             ("float".into(), std_types::FLOAT()),


### PR DESCRIPTION
Remove individual fixed-size numeric type bindings (u1, u8, u16, u32, u64, u128, ubig, i8, i16, i32, i64, i128, ibig, f32, f64, fbig) from the stdlib initializer in lentoc/lib/src/stdlib/init.rs. The stdlib now exposes the generic uint, int and float types only. This simplifies the public API and reduces redundancy in the standard library type registrations.