### PR TITLE
Add TypeAst::Binary for sum/function types

### DIFF
--- a/lentoc/lib/src/parser/parser.rs
+++ b/lentoc/lib/src/parser/parser.rs
@@ -75,6 +75,9 @@ pub fn from_stream<R: Read>(reader: R) -> Parser<R> {
 pub(crate) const COMMA_SYM: &str = ",";
 pub(crate) const ASSIGNMENT_SYM: &str = "=";
 pub(crate) const MEMBER_ACCESS_SYM: &str = ".";
+pub(crate) const FN_ARROW_SYM: &str = "->";
+pub(crate) const EFFECT_ASCRIPTION_SYM: &str = "!";
+pub(crate) const SUM_TYPE_SYM: &str = "|";
 
 /// Default operators used in the language grammar and required for parsing. \
 /// These operators are defined in the parser and are required to produce valid ASTs. \
@@ -108,7 +111,7 @@ pub fn intrinsic_operators() -> Vec<OpInfo> {
         },
         // Effect annotation operator (e.g. `A -> B ! { e }`)
         OpInfo {
-            symbol: "!".to_string(),
+            symbol: EFFECT_ASCRIPTION_SYM.to_string(),
             position: OpPos::Infix,
             precedence: prec::EFFECT_ASCRIPTION_PREC,
             associativity: OpAssoc::Left,
@@ -124,7 +127,7 @@ pub fn intrinsic_operators() -> Vec<OpInfo> {
         },
         // Function arrow (e.g. `A -> B`)
         OpInfo {
-            symbol: "->".to_string(),
+            symbol: FN_ARROW_SYM.to_string(),
             position: OpPos::Infix,
             precedence: prec::FUNCTION_ARROW_PREC,
             associativity: OpAssoc::Right,
@@ -132,7 +135,7 @@ pub fn intrinsic_operators() -> Vec<OpInfo> {
         },
         // Sum types (e.g. `int | str`)
         OpInfo {
-            symbol: "|".to_string(),
+            symbol: SUM_TYPE_SYM.to_string(),
             position: OpPos::Infix,
             precedence: prec::SUM_TYPE_PREC,
             associativity: OpAssoc::Left,
@@ -1011,7 +1014,7 @@ impl<R: Read> Parser<R> {
         // Use a min prec just above assignment so `= body` isn't consumed.
         let mut return_type_expr: Option<Ast> = None;
         if let Ok(t) = self.lexer.peek_token_not(pred::ignore, 0) {
-            if matches!(&t.token, Token::Operator(op) if op == "->") {
+            if matches!(&t.token, Token::Operator(op) if op == FN_ARROW_SYM) {
                 self.lexer.next_token().unwrap(); // consume ->
                 return_type_expr = Some(self.parse_expr(prec::FUNCTION_APP_PREC + 1)?);
             }

--- a/lentoc/lib/src/parser/tests.rs
+++ b/lentoc/lib/src/parser/tests.rs
@@ -5,8 +5,13 @@ mod tests {
             number::{Number, UnsignedInteger},
             value::{RecordKey, Value},
         },
-        parser::{ast::Ast, parser::from_string, pattern::BindPattern},
+        parser::{
+            ast::Ast,
+            parser::{from_string, FN_ARROW_SYM},
+            pattern::BindPattern,
+        },
         stdlib::init::{stdlib, Initializer},
+        type_checker::checked_ast::TypeAst,
         util::error::LineInfo,
     };
 
@@ -1184,6 +1189,32 @@ mod tests {
         if let Ast::TypeDecl { name, params, .. } = result {
             assert_eq!(name, "Foo");
             assert!(params.is_empty());
+        } else {
+            panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
+    fn type_decl_union() {
+        let result = parse_str_one("type X = int | bool", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { body, .. } = result {
+            assert!(matches!(body, TypeAst::Binary { .. }));
+            if let TypeAst::Binary { op, .. } = body {
+                assert_eq!(op.symbol, "|");
+            }
+        } else {
+            panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
+    fn type_decl_function_type() {
+        let result = parse_str_one("type Mapper = int -> bool", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { body, .. } = result {
+            assert!(matches!(body, TypeAst::Binary { .. }));
+            if let TypeAst::Binary { op, .. } = body {
+                assert_eq!(op.symbol, FN_ARROW_SYM);
+            }
         } else {
             panic!("Expected type declaration");
         }

--- a/lentoc/lib/src/type_checker/checked_ast.rs
+++ b/lentoc/lib/src/type_checker/checked_ast.rs
@@ -1,6 +1,7 @@
 use super::types::{std_types, FunctionType, GetType, TypeJudgements, TypeTrait};
 use crate::{
     interpreter::value::{Function, RecordKey, Value},
+    parser::op::OpInfo,
     parser::pattern::BindPattern,
     type_checker::types::Type,
     util::error::LineInfo,
@@ -34,6 +35,12 @@ pub enum TypeAst {
         fields: Vec<(RecordKey, TypeAst)>,
         info: LineInfo,
     },
+    Binary {
+        lhs: Box<TypeAst>,
+        op: OpInfo,
+        rhs: Box<TypeAst>,
+        info: LineInfo,
+    },
     Literal {
         value: Value,
         info: LineInfo,
@@ -54,6 +61,12 @@ impl Debug for TypeAst {
             Self::Record { fields, .. } => {
                 f.debug_struct("Record").field("fields", fields).finish()
             }
+            Self::Binary { lhs, op, rhs, .. } => f
+                .debug_struct("Binary")
+                .field("lhs", lhs)
+                .field("op", op)
+                .field("rhs", rhs)
+                .finish(),
             Self::Literal { value, .. } => f.debug_struct("Literal").field("value", value).finish(),
         }
     }
@@ -65,6 +78,7 @@ impl TypeAst {
             TypeAst::Identifier { info, .. } => info,
             TypeAst::Constructor { info, .. } => info,
             TypeAst::Record { info, .. } => info,
+            TypeAst::Binary { info, .. } => info,
             TypeAst::Literal { info, .. } => info,
         }
     }
@@ -93,6 +107,9 @@ impl TypeAst {
                         .collect::<Vec<String>>()
                         .join(", ")
                 )
+            }
+            TypeAst::Binary { lhs, op, rhs, .. } => {
+                format!("({} {} {})", lhs.print_expr(), op.symbol, rhs.print_expr())
             }
             TypeAst::Literal { value, .. } => value.pretty_print(),
         }
@@ -123,6 +140,14 @@ impl TypeAst {
                         .join(", ")
                 )
             }
+            TypeAst::Binary { lhs, op, rhs, .. } => {
+                format!(
+                    "({} {} {})",
+                    lhs.pretty_print(),
+                    op.symbol,
+                    rhs.pretty_print()
+                )
+            }
             TypeAst::Literal { value, .. } => value.pretty_print(),
         }
     }
@@ -144,6 +169,20 @@ impl PartialEq for TypeAst {
                     info: _,
                 },
             ) => l0 == r0 && l1 == r1,
+            (
+                Self::Binary {
+                    lhs: l0,
+                    op: l1,
+                    rhs: l2,
+                    info: _,
+                },
+                Self::Binary {
+                    lhs: r0,
+                    op: r1,
+                    rhs: r2,
+                    info: _,
+                },
+            ) => l0 == r0 && l1 == r1 && l2 == r2,
             (Self::Literal { value: l0, .. }, Self::Literal { value: r0, .. }) => l0 == r0,
             _ => false,
         }

--- a/lentoc/lib/src/type_checker/checker.rs
+++ b/lentoc/lib/src/type_checker/checker.rs
@@ -8,6 +8,7 @@ use crate::{
         ast::Ast,
         error::ParseError,
         op::{OpHandler, OpInfo, Operator, RuntimeOpHandler, StaticOpAst, StaticOpHandler},
+        parser::{FN_ARROW_SYM, SUM_TYPE_SYM},
         pattern::BindPattern,
     },
     util::error::{BaseError, BaseErrorExt, LineInfo},
@@ -546,6 +547,24 @@ impl TypeChecker<'_> {
                     .map(|(k, v)| Ok((k.clone(), self.check_type_expr(v)?)))
                     .collect::<TypeCheckerResult<Vec<_>>>()?;
                 Type::Record(fields)
+            }
+            TypeAst::Binary { lhs, op, rhs, info } => {
+                let lhs_ty = self.check_type_expr(lhs)?;
+                let rhs_ty = self.check_type_expr(rhs)?;
+                match op.symbol.as_str() {
+                    SUM_TYPE_SYM => Type::Sum(vec![lhs_ty, rhs_ty]).simplify(),
+                    FN_ARROW_SYM => Type::Function(Box::new(FunctionType::new(
+                        CheckedParam::from_str("_", lhs_ty),
+                        rhs_ty,
+                    ))),
+                    _ => {
+                        return Err(TypeError::new(
+                            format!("Unsupported type operator {}", op.symbol),
+                            info.clone(),
+                        )
+                        .into())
+                    }
+                }
             }
             TypeAst::Literal { value, info } => match value {
                 Value::Type(ty) => ty.clone(),

--- a/lentoc/lib/src/type_checker/specialize.rs
+++ b/lentoc/lib/src/type_checker/specialize.rs
@@ -3,7 +3,7 @@ use crate::{
         ast::Ast,
         error::ParseError,
         op::OpInfo,
-        parser::{ParseResult, ASSIGNMENT_SYM, COMMA_SYM},
+        parser::{ParseResult, ASSIGNMENT_SYM, COMMA_SYM, FN_ARROW_SYM, SUM_TYPE_SYM},
         pattern::BindPattern,
     },
     type_checker::checked_ast::{ParamAst, TypeAst},
@@ -595,7 +595,11 @@ pub fn is_type_expr(expr: &Ast, types: &HashSet<String>) -> bool {
     match expr {
         Ast::Identifier { name, .. } => types.contains(name),
         // Sum types like `int | str`
-        Ast::Binary { lhs, rhs, .. } => is_type_expr(lhs, types) && is_type_expr(rhs, types),
+        Ast::Binary { lhs, op, rhs, .. } => {
+            (op.symbol == SUM_TYPE_SYM || op.symbol == FN_ARROW_SYM)
+                && is_type_expr(lhs, types)
+                && is_type_expr(rhs, types)
+        }
         Ast::List { exprs, .. } if exprs.len() == 1 => is_type_expr(&exprs[0], types),
         Ast::Literal { .. } => false,
         Ast::FunctionCall { expr, arg, .. } => {
@@ -649,6 +653,16 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
             Ok(TypeAst::Constructor {
                 expr: Box::new(head),
                 params,
+                info,
+            })
+        }
+        Ast::Binary { lhs, op, rhs, info }
+            if op.symbol == SUM_TYPE_SYM || op.symbol == FN_ARROW_SYM =>
+        {
+            Ok(TypeAst::Binary {
+                lhs: Box::new(into_type_ast(*lhs)?),
+                op,
+                rhs: Box::new(into_type_ast(*rhs)?),
                 info,
             })
         }

--- a/lentoc/lib/src/type_checker/types.rs
+++ b/lentoc/lib/src/type_checker/types.rs
@@ -1,4 +1,4 @@
-use crate::{interpreter::value::RecordKey, util::str::Str};
+use crate::{interpreter::value::RecordKey, parser::parser::FN_ARROW_SYM, util::str::Str};
 use colorful::Colorful;
 use std::{
     collections::HashMap,
@@ -158,7 +158,7 @@ impl FunctionType {
         format!(
             "{} {} {}",
             self.param.ty.pretty_print_color(),
-            "->".dark_gray(),
+            FN_ARROW_SYM.dark_gray(),
             self.return_type.pretty_print_color()
         )
     }


### PR DESCRIPTION
Introduce explicit binary type operator support (e.g. `A | B`, `A -> B`) across the compiler pipeline. Adds parser symbols (FN_ARROW_SYM, EFFECT_ASCRIPTION_SYM, SUM_TYPE_SYM) and uses them when defining intrinsic operators and parsing return-type arrows. Introduces TypeAst::Binary to represent binary type expressions, updates debug/printing/eq logic, and extends specialize.rs to detect/convert binary type expressions. Type checker now maps binary type ASTs to Sum and Function types. Adds tests for parsing type unions and function types and updates pretty-printing to use the FN_ARROW_SYM constant.