### PR TITLE
Feature: Type syntax evolution — type annotations, array/list types, refinements, generics

### DIFF
--- a/examples/basic/types.lt
+++ b/examples/basic/types.lt
@@ -86,6 +86,9 @@ type ByteToByteMap = Map(u8, u8)
 type Ints = [int]
 type Points = [Point2D]
 
+type X = int
+type MyArr T = [T; 6]
+fn id(x: MyArr int) -> MyArr(X) = x
 
 // ----------------------------
 // Polymorphism (forall / all)
@@ -135,4 +138,3 @@ fn (Eq List T).eq<T: Eq>(xs, ys) = list_eq_by(T.eq, xs, ys)
 // A function signature with a type class constraint.
 fn member<a: Eq> :: a -> List a -> bool
 fn member(x, xs) = intrinsic.todo
-

--- a/examples/basic/types.lt
+++ b/examples/basic/types.lt
@@ -28,7 +28,7 @@ type path = Path
 // Refined base types have the form `{ v: B | phi }`.
 // You can also define a bounded integer range as a refinement.
 // `v` names the value being described; `phi` is in an SMT-decidable fragment.
-type Nat = { v: int | 0 <= v }
+type Nat = { v: int | v >= 0 }
 type NonZero = { v: int | v != 0 }
 type Age = { v: int | 0 <= v <= 200 }
 
@@ -97,6 +97,8 @@ fn id(x) = x
 
 fn compose<a, b, c> :: (b -> c) -> (a -> b) -> a -> c
 fn compose(f, g, x) = f(g(x))
+
+fn add_one(x: Nat) -> Nat = x + 1
 
 // Union/sum types at the type level
 type IntOrStr = int | str

--- a/lentoc/lib/src/parser/ast.rs
+++ b/lentoc/lib/src/parser/ast.rs
@@ -15,6 +15,12 @@ pub enum Ast {
     Tuple { exprs: Vec<Ast>, info: LineInfo },
     /// A dynamic list of elements.
     List { exprs: Vec<Ast>, info: LineInfo },
+    /// A static vector expression `[elem; len]`.
+    StaticVec {
+        elem: Box<Ast>,
+        len: Box<Ast>,
+        info: LineInfo,
+    },
     /// A record is a collection of key-value fields.
     Record {
         fields: Vec<(RecordKey, Ast)>,
@@ -107,6 +113,11 @@ impl Debug for Ast {
             Self::Literal { value, .. } => f.debug_struct("Literal").field("value", value).finish(),
             Self::Tuple { exprs, .. } => f.debug_struct("Tuple").field("exprs", exprs).finish(),
             Self::List { exprs, .. } => f.debug_struct("List").field("exprs", exprs).finish(),
+            Self::StaticVec { elem, len, .. } => f
+                .debug_struct("StaticVec")
+                .field("elem", elem)
+                .field("len", len)
+                .finish(),
             Self::Record { fields, .. } => {
                 f.debug_struct("Record").field("fields", fields).finish()
             }
@@ -213,6 +224,7 @@ impl Ast {
             Ast::Literal { info, .. } => info,
             Ast::Tuple { info, .. } => info,
             Ast::List { info, .. } => info,
+            Ast::StaticVec { info, .. } => info,
             Ast::Record { info, .. } => info,
             Ast::MemberAccess { info, .. } => info,
             Ast::Identifier { info, .. } => info,
@@ -258,6 +270,9 @@ impl Ast {
                     .collect::<Vec<String>>()
                     .join(", ")
             ),
+            Ast::StaticVec { elem, len, .. } => {
+                format!("[{}; {}]", elem.print_expr(), len.print_expr())
+            }
             Ast::Record { fields, .. } => format!(
                 "{{ {} }}",
                 fields
@@ -382,6 +397,18 @@ impl PartialEq for Ast {
             (Self::Literal { value: l0, .. }, Self::Literal { value: r0, .. }) => l0 == r0,
             (Self::Tuple { exprs: l0, .. }, Self::Tuple { exprs: r0, .. }) => l0 == r0,
             (Self::List { exprs: l0, info: _ }, Self::List { exprs: r0, info: _ }) => l0 == r0,
+            (
+                Self::StaticVec {
+                    elem: l0,
+                    len: l1,
+                    info: _,
+                },
+                Self::StaticVec {
+                    elem: r0,
+                    len: r1,
+                    info: _,
+                },
+            ) => l0 == r0 && l1 == r1,
             (Self::Record { fields: l0, .. }, Self::Record { fields: r0, .. }) => l0 == r0,
             (Self::Identifier { name: name1, .. }, Self::Identifier { name: name2, .. }) => {
                 name1 == name2

--- a/lentoc/lib/src/parser/ast.rs
+++ b/lentoc/lib/src/parser/ast.rs
@@ -15,8 +15,8 @@ pub enum Ast {
     Tuple { exprs: Vec<Ast>, info: LineInfo },
     /// A dynamic list of elements.
     List { exprs: Vec<Ast>, info: LineInfo },
-    /// A static vector expression `[elem; len]`.
-    StaticVec {
+    /// An array expression `[elem; len]`.
+    Array {
         elem: Box<Ast>,
         len: Box<Ast>,
         info: LineInfo,
@@ -113,8 +113,8 @@ impl Debug for Ast {
             Self::Literal { value, .. } => f.debug_struct("Literal").field("value", value).finish(),
             Self::Tuple { exprs, .. } => f.debug_struct("Tuple").field("exprs", exprs).finish(),
             Self::List { exprs, .. } => f.debug_struct("List").field("exprs", exprs).finish(),
-            Self::StaticVec { elem, len, .. } => f
-                .debug_struct("StaticVec")
+            Self::Array { elem, len, .. } => f
+                .debug_struct("Array")
                 .field("elem", elem)
                 .field("len", len)
                 .finish(),
@@ -224,7 +224,7 @@ impl Ast {
             Ast::Literal { info, .. } => info,
             Ast::Tuple { info, .. } => info,
             Ast::List { info, .. } => info,
-            Ast::StaticVec { info, .. } => info,
+            Ast::Array { info, .. } => info,
             Ast::Record { info, .. } => info,
             Ast::MemberAccess { info, .. } => info,
             Ast::Identifier { info, .. } => info,
@@ -270,7 +270,7 @@ impl Ast {
                     .collect::<Vec<String>>()
                     .join(", ")
             ),
-            Ast::StaticVec { elem, len, .. } => {
+            Ast::Array { elem, len, .. } => {
                 format!("[{}; {}]", elem.print_expr(), len.print_expr())
             }
             Ast::Record { fields, .. } => format!(
@@ -398,21 +398,27 @@ impl PartialEq for Ast {
             (Self::Tuple { exprs: l0, .. }, Self::Tuple { exprs: r0, .. }) => l0 == r0,
             (Self::List { exprs: l0, info: _ }, Self::List { exprs: r0, info: _ }) => l0 == r0,
             (
-                Self::StaticVec {
+                Self::Array {
                     elem: l0,
                     len: l1,
                     info: _,
                 },
-                Self::StaticVec {
+                Self::Array {
                     elem: r0,
                     len: r1,
                     info: _,
                 },
             ) => l0 == r0 && l1 == r1,
             (Self::Record { fields: l0, .. }, Self::Record { fields: r0, .. }) => l0 == r0,
-            (Self::Identifier { name: name1, .. }, Self::Identifier { name: name2, .. }) => {
-                name1 == name2
-            }
+            (
+                Self::MemberAccess {
+                    expr: l0, field: l1, ..
+                },
+                Self::MemberAccess {
+                    expr: r0, field: r1, ..
+                },
+            ) => l0 == r0 && l1 == r1,
+            (Self::Identifier { name: l0, .. }, Self::Identifier { name: r0, .. }) => l0 == r0,
             (
                 Self::FunctionCall {
                     expr: l0, arg: l1, ..

--- a/lentoc/lib/src/parser/parser.rs
+++ b/lentoc/lib/src/parser/parser.rs
@@ -149,6 +149,42 @@ pub fn intrinsic_operators() -> Vec<OpInfo> {
             associativity: OpAssoc::Left,
             allow_trailing: false,
         },
+        // Comparison operators (needed for refinement predicates)
+        OpInfo {
+            symbol: ">".to_string(),
+            position: OpPos::Infix,
+            precedence: prec::EQUALITY_PREC,
+            associativity: OpAssoc::Left,
+            allow_trailing: false,
+        },
+        OpInfo {
+            symbol: ">=".to_string(),
+            position: OpPos::Infix,
+            precedence: prec::EQUALITY_PREC,
+            associativity: OpAssoc::Left,
+            allow_trailing: false,
+        },
+        OpInfo {
+            symbol: "<".to_string(),
+            position: OpPos::Infix,
+            precedence: prec::EQUALITY_PREC,
+            associativity: OpAssoc::Left,
+            allow_trailing: false,
+        },
+        OpInfo {
+            symbol: "<=".to_string(),
+            position: OpPos::Infix,
+            precedence: prec::EQUALITY_PREC,
+            associativity: OpAssoc::Left,
+            allow_trailing: false,
+        },
+        OpInfo {
+            symbol: "!=".to_string(),
+            position: OpPos::Infix,
+            precedence: prec::EQUALITY_PREC,
+            associativity: OpAssoc::Left,
+            allow_trailing: false,
+        },
     ]
 }
 
@@ -358,15 +394,40 @@ impl<R: Read> Parser<R> {
     }
 
     fn parse_list(&mut self, start_info: LineInfo) -> ParseResult {
+        // Static vector syntax: [elem; len]
+        if let Ok(end) = self.lexer.peek_token(0) {
+            if end.token == Token::RightBracket {
+                self.lexer.next_token().unwrap();
+                return Ok(Ast::List {
+                    exprs: vec![],
+                    info: start_info.join(&end.info),
+                });
+            }
+        }
+        let first_expr = self.parse_expr(COMMA_PREC)?;
+        if let Ok(sep) = self.lexer.peek_token(0) {
+            if sep.token == Token::SemiColon {
+                self.lexer.next_token().unwrap(); // consume ';'
+                let len_expr = self.parse_expr(COMMA_PREC)?;
+                let end = self.parse_expected_eq(Token::RightBracket, "]")?;
+                return Ok(Ast::StaticVec {
+                    elem: Box::new(first_expr),
+                    len: Box::new(len_expr),
+                    info: start_info.join(&end.info),
+                });
+            }
+        }
+
         let mut exprs = Vec::new();
+        exprs.push(first_expr);
         while let Ok(end) = self.lexer.peek_token(0) {
             if end.token == Token::RightBracket {
                 break;
             }
-            exprs.push(self.parse_expr(COMMA_PREC)?);
             if let Ok(nt) = self.lexer.peek_token(0) {
                 if nt.token == Token::Operator(COMMA_SYM.to_string()) {
                     self.lexer.next_token().unwrap();
+                    exprs.push(self.parse_expr(COMMA_PREC)?);
                     continue;
                 } else if nt.token == Token::RightBracket {
                     break;
@@ -1106,7 +1167,9 @@ impl<R: Read> Parser<R> {
         };
         let name_info = name_token.info;
 
-        // Check for optional parenthesized parameter list: type Name(Param1, Param2)
+        // Optional type parameters:
+        // - parenthesized: `type Name(T, U) = ...`
+        // - bare: `type Name T U = ...`
         let params: Vec<Ast> = if let Ok(t) = self.lexer.peek_token_not(pred::ignore, 0) {
             if matches!(t.token, Token::LeftParen { .. }) {
                 self.lexer.next_token().unwrap(); // consume (
@@ -1151,7 +1214,20 @@ impl<R: Read> Parser<R> {
                 }
                 p
             } else {
-                vec![]
+                let mut p = Vec::new();
+                while let Ok(next) = self.lexer.peek_token_not(pred::ignore, 0) {
+                    if next.token == Token::Operator("=".to_string()) {
+                        break;
+                    }
+                    let Token::Identifier(name) = &next.token else {
+                        break;
+                    };
+                    let name = name.clone();
+                    let info = next.info.clone();
+                    self.lexer.next_token().unwrap(); // consume identifier
+                    p.push(Ast::Identifier { name, info });
+                }
+                p
             }
         } else {
             vec![]

--- a/lentoc/lib/src/parser/parser.rs
+++ b/lentoc/lib/src/parser/parser.rs
@@ -872,14 +872,40 @@ impl<R: Read> Parser<R> {
 
     /// Parse a `let` statement after the `let` keyword has been consumed.
     fn parse_let_stmt(&mut self) -> ParseResult {
-        let expr = self.parse_expr(0)?;
-        match expr {
-            Ast::Let { .. } => Ok(expr),
-            _ => Err(ParseError::new(
-                "Expected `let <pattern> = <expr>`".to_string(),
-                expr.info().clone(),
-            )),
+        let target_expr = self.parse_term()?;
+        let mut annotation = None;
+
+        // Check for optional type annotation `: type`
+        if let Ok(next) = self.lexer.peek_token_not(pred::ignore, 0) {
+            if matches!(next.token, Token::Colon) {
+                self.lexer.next_token().unwrap(); // consume ':'
+                let ann_expr = self.parse_expr(prec::COMMA_PREC + 1)?;
+                annotation =
+                    Some(crate::type_checker::specialize::into_type_ast(ann_expr)?);
+            }
         }
+
+        // Expect `=`
+        if let Ok(next) = self.lexer.peek_token_not(pred::ignore, 0) {
+            if let Token::Operator(op) = &next.token {
+                if op.as_str() == ASSIGNMENT_SYM {
+                    self.lexer.next_token().unwrap(); // consume '='
+                    let value = self.parse_expr(0)?;
+                    let info = target_expr.info().join(value.info());
+                    return Ok(Ast::Let {
+                        target: BindPattern::from_expr(target_expr)?,
+                        expr: Box::new(value),
+                        annotation,
+                        info,
+                    });
+                }
+            }
+        }
+
+        Err(ParseError::new(
+            "Expected `let <pattern> = <expr>`".to_string(),
+            target_expr.info().clone(),
+        ))
     }
 
     /// Parse a top-level expression.

--- a/lentoc/lib/src/parser/parser.rs
+++ b/lentoc/lib/src/parser/parser.rs
@@ -410,7 +410,7 @@ impl<R: Read> Parser<R> {
                 self.lexer.next_token().unwrap(); // consume ';'
                 let len_expr = self.parse_expr(COMMA_PREC)?;
                 let end = self.parse_expected_eq(Token::RightBracket, "]")?;
-                return Ok(Ast::StaticVec {
+                return Ok(Ast::Array {
                     elem: Box::new(first_expr),
                     len: Box::new(len_expr),
                     info: start_info.join(&end.info),

--- a/lentoc/lib/src/parser/tests.rs
+++ b/lentoc/lib/src/parser/tests.rs
@@ -1284,6 +1284,57 @@ mod tests {
     }
 
     #[test]
+    fn type_decl_record_type() {
+        let result = parse_str_one("type Eq = { eq: Self -> Self -> bool }", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { body, .. } = result {
+            assert!(matches!(body, TypeAst::Record { .. }));
+        } else {
+            panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
+    fn type_decl_refinement_type() {
+        let result = parse_str_one("type Nat = { v: int | v >= 0 }", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { body, .. } = result {
+            assert!(matches!(body, TypeAst::Refinement { .. }));
+        } else {
+            panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
+    fn type_decl_static_vec_generic_bare_param() {
+        let result = parse_str_one("type MyArr T = [T; 6]", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { params, body, .. } = result {
+            assert_eq!(params.len(), 1);
+            assert!(matches!(body, TypeAst::StaticVector { .. }));
+            if let TypeAst::StaticVector { len, .. } = body {
+                assert_eq!(len, 6);
+            }
+        } else {
+            panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
+    fn type_decl_apply_bare_and_paren() {
+        let result = parse_str_one("type A = MyArr X", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { body, .. } = result {
+            assert!(matches!(body, TypeAst::Application { .. }));
+        } else {
+            panic!("Expected type declaration");
+        }
+
+        let result = parse_str_one("type B = MyArr(X)", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { body, .. } = result {
+            assert!(matches!(body, TypeAst::Application { .. }));
+        } else {
+            panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
     fn function_def_bind_pattern_params() {
         let result = parse_str_one("fn f((x, y), { a: a }) = x", None).unwrap();
         if let Ast::FunctionDef { params, .. } = result {

--- a/lentoc/lib/src/parser/tests.rs
+++ b/lentoc/lib/src/parser/tests.rs
@@ -1369,4 +1369,36 @@ mod tests {
             panic!("Expected function definition");
         }
     }
+
+    #[test]
+    fn type_decl_literal_sum() {
+        let result = parse_str_one("type FewNums = 5 | 6 | 7", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { body, .. } = result {
+            assert!(matches!(body, TypeAst::Sum { .. }));
+            if let TypeAst::Sum { variants, .. } = body {
+                assert_eq!(variants.len(), 3);
+                for variant in &variants {
+                    assert!(matches!(variant, TypeAst::Literal { .. }));
+                }
+            }
+        } else {
+            panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
+    fn let_with_literal_sum_annotation() {
+        let result = parse_str_one("let x: \"hello\" | false = \"hello\"", Some(&stdlib())).unwrap();
+        if let Ast::Let { annotation, .. } = result {
+            let ann = annotation.unwrap();
+            assert!(matches!(ann, TypeAst::Sum { .. }));
+            if let TypeAst::Sum { variants, .. } = ann {
+                assert_eq!(variants.len(), 2);
+                assert!(matches!(&variants[0], TypeAst::Literal { .. }));
+                assert!(matches!(&variants[1], TypeAst::Literal { .. }));
+            }
+        } else {
+            panic!("Expected let binding");
+        }
+    }
 }

--- a/lentoc/lib/src/parser/tests.rs
+++ b/lentoc/lib/src/parser/tests.rs
@@ -5,11 +5,7 @@ mod tests {
             number::{Number, UnsignedInteger},
             value::{RecordKey, Value},
         },
-        parser::{
-            ast::Ast,
-            parser::from_string,
-            pattern::BindPattern,
-        },
+        parser::{ast::Ast, parser::from_string, pattern::BindPattern},
         stdlib::init::{stdlib, Initializer},
         type_checker::checked_ast::TypeAst,
         util::error::LineInfo,
@@ -1285,7 +1281,8 @@ mod tests {
 
     #[test]
     fn type_decl_record_type() {
-        let result = parse_str_one("type Eq = { eq: Self -> Self -> bool }", Some(&stdlib())).unwrap();
+        let result =
+            parse_str_one("type Eq = { eq: Self -> Self -> bool }", Some(&stdlib())).unwrap();
         if let Ast::TypeDecl { body, .. } = result {
             assert!(matches!(body, TypeAst::Record { .. }));
         } else {
@@ -1308,8 +1305,8 @@ mod tests {
         let result = parse_str_one("type MyArr T = [T; 6]", Some(&stdlib())).unwrap();
         if let Ast::TypeDecl { params, body, .. } = result {
             assert_eq!(params.len(), 1);
-            assert!(matches!(body, TypeAst::StaticVector { .. }));
-            if let TypeAst::StaticVector { len, .. } = body {
+            assert!(matches!(body, TypeAst::Array { .. }));
+            if let TypeAst::Array { len, .. } = body {
                 assert_eq!(len, 6);
             }
         } else {

--- a/lentoc/lib/src/parser/tests.rs
+++ b/lentoc/lib/src/parser/tests.rs
@@ -7,7 +7,7 @@ mod tests {
         },
         parser::{
             ast::Ast,
-            parser::{from_string, FN_ARROW_SYM},
+            parser::from_string,
             pattern::BindPattern,
         },
         stdlib::init::{stdlib, Initializer},
@@ -1198,9 +1198,9 @@ mod tests {
     fn type_decl_union() {
         let result = parse_str_one("type X = int | bool", Some(&stdlib())).unwrap();
         if let Ast::TypeDecl { body, .. } = result {
-            assert!(matches!(body, TypeAst::Binary { .. }));
-            if let TypeAst::Binary { op, .. } = body {
-                assert_eq!(op.symbol, "|");
+            assert!(matches!(body, TypeAst::Sum { .. }));
+            if let TypeAst::Sum { variants, .. } = body {
+                assert_eq!(variants.len(), 2);
             }
         } else {
             panic!("Expected type declaration");
@@ -1211,10 +1211,73 @@ mod tests {
     fn type_decl_function_type() {
         let result = parse_str_one("type Mapper = int -> bool", Some(&stdlib())).unwrap();
         if let Ast::TypeDecl { body, .. } = result {
-            assert!(matches!(body, TypeAst::Binary { .. }));
-            if let TypeAst::Binary { op, .. } = body {
-                assert_eq!(op.symbol, FN_ARROW_SYM);
+            assert!(matches!(body, TypeAst::Lambda { .. }));
+            if let TypeAst::Lambda { eff, .. } = body {
+                assert!(eff.is_none());
             }
+        } else {
+            panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
+    fn type_decl_function_type_with_effect() {
+        let result = parse_str_one("type Mapper = int -> bool ! io", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { body, .. } = result {
+            assert!(matches!(body, TypeAst::Lambda { .. }));
+            if let TypeAst::Lambda { eff, .. } = body {
+                assert!(eff.is_some());
+            }
+        } else {
+            panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
+    fn type_decl_application_paren_args() {
+        let result = parse_str_one("type Dict = Map(int, int)", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { body, .. } = result {
+            assert!(matches!(body, TypeAst::Application { .. }));
+            if let TypeAst::Application { expr, args, .. } = body {
+                assert!(matches!(*expr, TypeAst::Identifier { .. }));
+                assert_eq!(args.len(), 2);
+            }
+        } else {
+            panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
+    fn type_decl_application_juxtaposition_args() {
+        let result = parse_str_one("type Dict = Map int int", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { body, .. } = result {
+            assert!(matches!(body, TypeAst::Application { .. }));
+            if let TypeAst::Application { args, .. } = body {
+                assert_eq!(args.len(), 2);
+            }
+        } else {
+            panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
+    fn type_decl_tuple_type() {
+        let result = parse_str_one("type Pair = (int, bool)", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { body, .. } = result {
+            assert!(matches!(body, TypeAst::Tuple { .. }));
+            if let TypeAst::Tuple { items, .. } = body {
+                assert_eq!(items.len(), 2);
+            }
+        } else {
+            panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
+    fn type_decl_singleton_literal() {
+        let result = parse_str_one("type FortyTwo = 42", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { body, .. } = result {
+            assert!(matches!(body, TypeAst::Literal { .. }));
         } else {
             panic!("Expected type declaration");
         }

--- a/lentoc/lib/src/parser/tests.rs
+++ b/lentoc/lib/src/parser/tests.rs
@@ -1315,6 +1315,19 @@ mod tests {
     }
 
     #[test]
+    fn type_decl_list_type() {
+        let result = parse_str_one("type Foo = [int]", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { body, .. } = result {
+            assert!(matches!(body, TypeAst::List { .. }));
+            if let TypeAst::List { elem, .. } = &body {
+                assert!(matches!(elem.as_ref(), TypeAst::Identifier { name, .. } if name == "int"));
+            }
+        } else {
+            panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
     fn type_decl_apply_bare_and_paren() {
         let result = parse_str_one("type A = MyArr X", Some(&stdlib())).unwrap();
         if let Ast::TypeDecl { body, .. } = result {

--- a/lentoc/lib/src/parser/tests.rs
+++ b/lentoc/lib/src/parser/tests.rs
@@ -286,26 +286,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "legacy assignment syntax"]
-    fn typed_assignment() {
-        let result = parse_str_one("int x = 1", Some(&stdlib()));
-        let result = result.unwrap();
-
-        assert!(matches!(result, Ast::Let { .. }));
-        if let Ast::Let { target, expr, .. } = &result {
-            assert!(matches!(target, BindPattern::Variable { .. }));
-            assert!(matches!(*expr.to_owned(), Ast::Literal { .. }));
-            // if let Some(annotation) = annotation {
-            //     assert!(matches!(annotation, TypeAst::Identifier { .. }));
-            //     let TypeAst::Identifier { name, .. } = &annotation else {
-            //         panic!("Expected identifier");
-            //     };
-            //     assert_eq!(name, "int");
-            // }
-        }
-    }
-
-    #[test]
     fn untyped_assignment() {
         let result = parse_str_one("x = 1", Some(&stdlib()));
         let result = result.unwrap();
@@ -660,25 +640,6 @@ mod tests {
             Some(&stdlib()),
         )
         .unwrap();
-    }
-
-    #[test]
-    #[ignore = "legacy assignment syntax"]
-    fn assignment_with_type() {
-        let result = parse_str_one("int x = 123", Some(&stdlib()));
-        if let Ast::Let { target, expr, .. } = result.unwrap() {
-            assert!(matches!(target, BindPattern::Variable { .. }));
-            if let BindPattern::Variable { name, .. } = target {
-                assert_eq!(name, "x");
-            }
-            // assert!(annotation.is_some());
-            // if let Some(TypeAst::Identifier { name, .. }) = &annotation {
-            //     assert_eq!(name, "int");
-            // }
-            assert!(matches!(*expr, Ast::Literal { .. }));
-        } else {
-            panic!("Expected assignment");
-        }
     }
 
     #[test]

--- a/lentoc/lib/src/parser/tests.rs
+++ b/lentoc/lib/src/parser/tests.rs
@@ -1363,6 +1363,41 @@ mod tests {
     }
 
     #[test]
+    fn let_with_type_annotation() {
+        let result = parse_str_one("let x: int = 5", Some(&stdlib())).unwrap();
+        if let Ast::Let { target, annotation, .. } = result {
+            assert!(matches!(target, BindPattern::Variable { .. }));
+            assert!(annotation.is_some());
+            assert!(matches!(annotation.unwrap(), TypeAst::Identifier { name, .. } if name == "int"));
+        } else {
+            panic!("Expected let binding");
+        }
+    }
+
+    #[test]
+    fn let_with_list_type_annotation() {
+        let result = parse_str_one("let xs: [int] = [1, 2, 3]", Some(&stdlib())).unwrap();
+        if let Ast::Let { annotation, .. } = result {
+            assert!(annotation.is_some());
+            assert!(matches!(annotation.unwrap(), TypeAst::List { .. }));
+        } else {
+            panic!("Expected let binding");
+        }
+    }
+
+    #[test]
+    fn let_with_tuple_type_annotation() {
+        let result =
+            parse_str_one("let pair: (int, bool) = (1, true)", Some(&stdlib())).unwrap();
+        if let Ast::Let { annotation, .. } = result {
+            assert!(annotation.is_some());
+            assert!(matches!(annotation.unwrap(), TypeAst::Tuple { .. }));
+        } else {
+            panic!("Expected let binding");
+        }
+    }
+
+    #[test]
     fn function_def_typed_params_parse() {
         let result = parse_str_one("fn id(x: u8) = x", Some(&stdlib())).unwrap();
         if let Ast::FunctionDef { params, .. } = result {

--- a/lentoc/lib/src/parser/tests.rs
+++ b/lentoc/lib/src/parser/tests.rs
@@ -1170,7 +1170,7 @@ mod tests {
         if let Ast::TypeDecl { body, .. } = result {
             assert!(matches!(body, TypeAst::Lambda { .. }));
             if let TypeAst::Lambda { eff, .. } = body {
-                assert!(eff.is_none());
+                assert!(eff.is_empty());
             }
         } else {
             panic!("Expected type declaration");
@@ -1183,7 +1183,7 @@ mod tests {
         if let Ast::TypeDecl { body, .. } = result {
             assert!(matches!(body, TypeAst::Lambda { .. }));
             if let TypeAst::Lambda { eff, .. } = body {
-                assert!(eff.is_some());
+                assert!(!eff.is_empty());
             }
         } else {
             panic!("Expected type declaration");

--- a/lentoc/lib/src/type_checker/checked_ast.rs
+++ b/lentoc/lib/src/type_checker/checked_ast.rs
@@ -1,6 +1,7 @@
 use super::types::{std_types, FunctionType, GetType, TypeJudgements, TypeTrait};
 use crate::{
     interpreter::value::{Function, RecordKey, Value},
+    parser::ast::Ast,
     parser::pattern::BindPattern,
     type_checker::types::Type,
     util::error::LineInfo,
@@ -34,8 +35,19 @@ pub enum TypeAst {
         items: Vec<TypeAst>,
         info: LineInfo,
     },
+    StaticVector {
+        elem: Box<TypeAst>,
+        len: usize,
+        info: LineInfo,
+    },
     Record {
         fields: Vec<(RecordKey, TypeAst)>,
+        info: LineInfo,
+    },
+    Refinement {
+        binder: RecordKey,
+        base: Box<TypeAst>,
+        predicate: Box<Ast>,
         info: LineInfo,
     },
     Sum {
@@ -66,9 +78,25 @@ impl Debug for TypeAst {
                 .field("args", args)
                 .finish(),
             Self::Tuple { items, .. } => f.debug_struct("Tuple").field("items", items).finish(),
+            Self::StaticVector { elem, len, .. } => f
+                .debug_struct("StaticVector")
+                .field("elem", elem)
+                .field("len", len)
+                .finish(),
             Self::Record { fields, .. } => {
                 f.debug_struct("Record").field("fields", fields).finish()
             }
+            Self::Refinement {
+                binder,
+                base,
+                predicate,
+                ..
+            } => f
+                .debug_struct("Refinement")
+                .field("binder", binder)
+                .field("base", base)
+                .field("predicate", predicate)
+                .finish(),
             Self::Sum { variants, .. } => {
                 f.debug_struct("Sum").field("variants", variants).finish()
             }
@@ -89,7 +117,9 @@ impl TypeAst {
             TypeAst::Identifier { info, .. } => info,
             TypeAst::Application { info, .. } => info,
             TypeAst::Tuple { info, .. } => info,
+            TypeAst::StaticVector { info, .. } => info,
             TypeAst::Record { info, .. } => info,
+            TypeAst::Refinement { info, .. } => info,
             TypeAst::Sum { info, .. } => info,
             TypeAst::Lambda { info, .. } => info,
             TypeAst::Literal { info, .. } => info,
@@ -125,6 +155,9 @@ impl TypeAst {
                     )
                 }
             }
+            TypeAst::StaticVector { elem, len, .. } => {
+                format!("[{}; {}]", elem.print_expr(), len)
+            }
             TypeAst::Record { fields, .. } => {
                 format!(
                     "{{ {} }}",
@@ -134,6 +167,14 @@ impl TypeAst {
                         .collect::<Vec<String>>()
                         .join(", ")
                 )
+            }
+            TypeAst::Refinement {
+                binder,
+                base,
+                predicate,
+                ..
+            } => {
+                format!("{{ {}: {} | {} }}", binder, base.print_expr(), predicate.print_expr())
             }
             TypeAst::Sum { variants, .. } => {
                 format!(
@@ -190,6 +231,9 @@ impl TypeAst {
                     )
                 }
             }
+            TypeAst::StaticVector { elem, len, .. } => {
+                format!("[{}; {}]", elem.pretty_print(), len)
+            }
             TypeAst::Record { fields, .. } => {
                 format!(
                     "{{ {} }}",
@@ -199,6 +243,14 @@ impl TypeAst {
                         .collect::<Vec<String>>()
                         .join(", ")
                 )
+            }
+            TypeAst::Refinement {
+                binder,
+                base,
+                predicate,
+                ..
+            } => {
+                format!("{{ {}: {} | {} }}", binder, base.pretty_print(), predicate.print_expr())
             }
             TypeAst::Sum { variants, .. } => {
                 format!(
@@ -254,6 +306,18 @@ impl PartialEq for TypeAst {
                 },
             ) => l0 == r0,
             (
+                Self::StaticVector {
+                    elem: l0,
+                    len: l1,
+                    info: _,
+                },
+                Self::StaticVector {
+                    elem: r0,
+                    len: r1,
+                    info: _,
+                },
+            ) => l0 == r0 && l1 == r1,
+            (
                 Self::Record {
                     fields: l0,
                     info: _,
@@ -263,6 +327,20 @@ impl PartialEq for TypeAst {
                     info: _,
                 },
             ) => l0 == r0,
+            (
+                Self::Refinement {
+                    binder: l0,
+                    base: l1,
+                    predicate: l2,
+                    info: _,
+                },
+                Self::Refinement {
+                    binder: r0,
+                    base: r1,
+                    predicate: r2,
+                    info: _,
+                },
+            ) => l0 == r0 && l1 == r1 && l2 == r2,
             (
                 Self::Sum {
                     variants: l0,

--- a/lentoc/lib/src/type_checker/checked_ast.rs
+++ b/lentoc/lib/src/type_checker/checked_ast.rs
@@ -8,6 +8,27 @@ use crate::{
 };
 use std::fmt::Debug;
 
+/// A single effect, e.g. `IO`, or `throw X` (future).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Effect {
+    pub name: String,
+    pub params: Vec<String>,
+}
+
+impl Effect {
+    pub fn print_expr(&self) -> String {
+        if self.params.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{}({})", self.name, self.params.join(", "))
+        }
+    }
+
+    pub fn pretty_print(&self) -> String {
+        self.print_expr()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ParamAst {
     pub ty: Option<TypeAst>,
@@ -61,7 +82,7 @@ pub enum TypeAst {
     Lambda {
         lhs: Box<TypeAst>,
         rhs: Box<TypeAst>,
-        eff: Option<Box<TypeAst>>,
+        eff: Vec<Effect>,
         info: LineInfo,
     },
     Literal {
@@ -202,15 +223,15 @@ impl TypeAst {
                 )
             }
             TypeAst::Lambda { lhs, rhs, eff, .. } => {
-                if let Some(eff) = eff {
+                if eff.is_empty() {
+                    format!("({} -> {})", lhs.print_expr(), rhs.print_expr())
+                } else {
                     format!(
                         "({} -> {} ! {})",
                         lhs.print_expr(),
                         rhs.print_expr(),
-                        eff.print_expr()
+                        eff.iter().map(|e| e.print_expr()).collect::<Vec<_>>().join(", ")
                     )
-                } else {
-                    format!("({} -> {})", lhs.print_expr(), rhs.print_expr())
                 }
             }
             TypeAst::Literal { value, .. } => value.pretty_print(),
@@ -284,15 +305,15 @@ impl TypeAst {
                 )
             }
             TypeAst::Lambda { lhs, rhs, eff, .. } => {
-                if let Some(eff) = eff {
+                if eff.is_empty() {
+                    format!("({} -> {})", lhs.pretty_print(), rhs.pretty_print())
+                } else {
                     format!(
                         "({} -> {} ! {})",
                         lhs.pretty_print(),
                         rhs.pretty_print(),
-                        eff.pretty_print()
+                        eff.iter().map(|e| e.pretty_print()).collect::<Vec<_>>().join(", ")
                     )
-                } else {
-                    format!("({} -> {})", lhs.pretty_print(), rhs.pretty_print())
                 }
             }
             TypeAst::Literal { value, .. } => value.pretty_print(),

--- a/lentoc/lib/src/type_checker/checked_ast.rs
+++ b/lentoc/lib/src/type_checker/checked_ast.rs
@@ -40,6 +40,10 @@ pub enum TypeAst {
         len: usize,
         info: LineInfo,
     },
+    List {
+        elem: Box<TypeAst>,
+        info: LineInfo,
+    },
     Record {
         fields: Vec<(RecordKey, TypeAst)>,
         info: LineInfo,
@@ -83,6 +87,10 @@ impl Debug for TypeAst {
                 .field("elem", elem)
                 .field("len", len)
                 .finish(),
+            Self::List { elem, .. } => f
+                .debug_struct("List")
+                .field("elem", elem)
+                .finish(),
             Self::Record { fields, .. } => {
                 f.debug_struct("Record").field("fields", fields).finish()
             }
@@ -118,6 +126,7 @@ impl TypeAst {
             TypeAst::Application { info, .. } => info,
             TypeAst::Tuple { info, .. } => info,
             TypeAst::Array { info, .. } => info,
+            TypeAst::List { info, .. } => info,
             TypeAst::Record { info, .. } => info,
             TypeAst::Refinement { info, .. } => info,
             TypeAst::Sum { info, .. } => info,
@@ -155,6 +164,9 @@ impl TypeAst {
             }
             TypeAst::Array { elem, len, .. } => {
                 format!("[{}; {}]", elem.print_expr(), len)
+            }
+            TypeAst::List { elem, .. } => {
+                format!("[{}]", elem.print_expr())
             }
             TypeAst::Record { fields, .. } => {
                 format!(
@@ -235,6 +247,9 @@ impl TypeAst {
             TypeAst::Array { elem, len, .. } => {
                 format!("[{}; {}]", elem.pretty_print(), len)
             }
+            TypeAst::List { elem, .. } => {
+                format!("[{}]", elem.pretty_print())
+            }
             TypeAst::Record { fields, .. } => {
                 format!(
                     "{{ {} }}",
@@ -314,6 +329,10 @@ impl PartialEq for TypeAst {
                     info: _,
                 },
             ) => l0 == r0 && l1 == r1,
+            (
+                Self::List { elem: l0, info: _ },
+                Self::List { elem: r0, info: _ },
+            ) => l0 == r0,
             (
                 Self::Record {
                     fields: l0,

--- a/lentoc/lib/src/type_checker/checked_ast.rs
+++ b/lentoc/lib/src/type_checker/checked_ast.rs
@@ -35,7 +35,7 @@ pub enum TypeAst {
         items: Vec<TypeAst>,
         info: LineInfo,
     },
-    StaticVector {
+    Array {
         elem: Box<TypeAst>,
         len: usize,
         info: LineInfo,
@@ -78,8 +78,8 @@ impl Debug for TypeAst {
                 .field("args", args)
                 .finish(),
             Self::Tuple { items, .. } => f.debug_struct("Tuple").field("items", items).finish(),
-            Self::StaticVector { elem, len, .. } => f
-                .debug_struct("StaticVector")
+            Self::Array { elem, len, .. } => f
+                .debug_struct("Array")
                 .field("elem", elem)
                 .field("len", len)
                 .finish(),
@@ -117,7 +117,7 @@ impl TypeAst {
             TypeAst::Identifier { info, .. } => info,
             TypeAst::Application { info, .. } => info,
             TypeAst::Tuple { info, .. } => info,
-            TypeAst::StaticVector { info, .. } => info,
+            TypeAst::Array { info, .. } => info,
             TypeAst::Record { info, .. } => info,
             TypeAst::Refinement { info, .. } => info,
             TypeAst::Sum { info, .. } => info,
@@ -129,9 +129,7 @@ impl TypeAst {
     pub fn print_expr(&self) -> String {
         match self {
             TypeAst::Identifier { name, .. } => name.clone(),
-            TypeAst::Application {
-                expr, args, ..
-            } => {
+            TypeAst::Application { expr, args, .. } => {
                 format!(
                     "{}({})",
                     expr.print_expr(),
@@ -155,7 +153,7 @@ impl TypeAst {
                     )
                 }
             }
-            TypeAst::StaticVector { elem, len, .. } => {
+            TypeAst::Array { elem, len, .. } => {
                 format!("[{}; {}]", elem.print_expr(), len)
             }
             TypeAst::Record { fields, .. } => {
@@ -174,7 +172,12 @@ impl TypeAst {
                 predicate,
                 ..
             } => {
-                format!("{{ {}: {} | {} }}", binder, base.print_expr(), predicate.print_expr())
+                format!(
+                    "{{ {}: {} | {} }}",
+                    binder,
+                    base.print_expr(),
+                    predicate.print_expr()
+                )
             }
             TypeAst::Sum { variants, .. } => {
                 format!(
@@ -205,9 +208,7 @@ impl TypeAst {
     pub fn pretty_print(&self) -> String {
         match self {
             TypeAst::Identifier { name, .. } => name.clone(),
-            TypeAst::Application {
-                expr, args, ..
-            } => {
+            TypeAst::Application { expr, args, .. } => {
                 format!(
                     "{}({})",
                     expr.pretty_print(),
@@ -231,7 +232,7 @@ impl TypeAst {
                     )
                 }
             }
-            TypeAst::StaticVector { elem, len, .. } => {
+            TypeAst::Array { elem, len, .. } => {
                 format!("[{}; {}]", elem.pretty_print(), len)
             }
             TypeAst::Record { fields, .. } => {
@@ -250,7 +251,12 @@ impl TypeAst {
                 predicate,
                 ..
             } => {
-                format!("{{ {}: {} | {} }}", binder, base.pretty_print(), predicate.print_expr())
+                format!(
+                    "{{ {}: {} | {} }}",
+                    binder,
+                    base.pretty_print(),
+                    predicate.print_expr()
+                )
             }
             TypeAst::Sum { variants, .. } => {
                 format!(
@@ -295,23 +301,14 @@ impl PartialEq for TypeAst {
                     info: _,
                 },
             ) => l0 == r0 && l1 == r1,
+            (Self::Tuple { items: l0, info: _ }, Self::Tuple { items: r0, info: _ }) => l0 == r0,
             (
-                Self::Tuple {
-                    items: l0,
-                    info: _,
-                },
-                Self::Tuple {
-                    items: r0,
-                    info: _,
-                },
-            ) => l0 == r0,
-            (
-                Self::StaticVector {
+                Self::Array {
                     elem: l0,
                     len: l1,
                     info: _,
                 },
-                Self::StaticVector {
+                Self::Array {
                     elem: r0,
                     len: r1,
                     info: _,

--- a/lentoc/lib/src/type_checker/checked_ast.rs
+++ b/lentoc/lib/src/type_checker/checked_ast.rs
@@ -1,7 +1,6 @@
 use super::types::{std_types, FunctionType, GetType, TypeJudgements, TypeTrait};
 use crate::{
     interpreter::value::{Function, RecordKey, Value},
-    parser::op::OpInfo,
     parser::pattern::BindPattern,
     type_checker::types::Type,
     util::error::LineInfo,
@@ -26,19 +25,27 @@ pub enum TypeAst {
         name: String,
         info: LineInfo,
     },
-    Constructor {
+    Application {
         expr: Box<TypeAst>,
-        params: Vec<TypeAst>,
+        args: Vec<TypeAst>,
+        info: LineInfo,
+    },
+    Tuple {
+        items: Vec<TypeAst>,
         info: LineInfo,
     },
     Record {
         fields: Vec<(RecordKey, TypeAst)>,
         info: LineInfo,
     },
-    Binary {
+    Sum {
+        variants: Vec<TypeAst>,
+        info: LineInfo,
+    },
+    Lambda {
         lhs: Box<TypeAst>,
-        op: OpInfo,
         rhs: Box<TypeAst>,
+        eff: Option<Box<TypeAst>>,
         info: LineInfo,
     },
     Literal {
@@ -53,19 +60,23 @@ impl Debug for TypeAst {
             Self::Identifier { name, .. } => {
                 f.debug_struct("Identifier").field("name", name).finish()
             }
-            Self::Constructor { expr, params, .. } => f
-                .debug_struct("Constructor")
+            Self::Application { expr, args, .. } => f
+                .debug_struct("Application")
                 .field("expr", expr)
-                .field("params", params)
+                .field("args", args)
                 .finish(),
+            Self::Tuple { items, .. } => f.debug_struct("Tuple").field("items", items).finish(),
             Self::Record { fields, .. } => {
                 f.debug_struct("Record").field("fields", fields).finish()
             }
-            Self::Binary { lhs, op, rhs, .. } => f
-                .debug_struct("Binary")
+            Self::Sum { variants, .. } => {
+                f.debug_struct("Sum").field("variants", variants).finish()
+            }
+            Self::Lambda { lhs, rhs, eff, .. } => f
+                .debug_struct("Lambda")
                 .field("lhs", lhs)
-                .field("op", op)
                 .field("rhs", rhs)
+                .field("eff", eff)
                 .finish(),
             Self::Literal { value, .. } => f.debug_struct("Literal").field("value", value).finish(),
         }
@@ -76,9 +87,11 @@ impl TypeAst {
     pub fn info(&self) -> &LineInfo {
         match self {
             TypeAst::Identifier { info, .. } => info,
-            TypeAst::Constructor { info, .. } => info,
+            TypeAst::Application { info, .. } => info,
+            TypeAst::Tuple { info, .. } => info,
             TypeAst::Record { info, .. } => info,
-            TypeAst::Binary { info, .. } => info,
+            TypeAst::Sum { info, .. } => info,
+            TypeAst::Lambda { info, .. } => info,
             TypeAst::Literal { info, .. } => info,
         }
     }
@@ -86,8 +99,8 @@ impl TypeAst {
     pub fn print_expr(&self) -> String {
         match self {
             TypeAst::Identifier { name, .. } => name.clone(),
-            TypeAst::Constructor {
-                expr, params: args, ..
+            TypeAst::Application {
+                expr, args, ..
             } => {
                 format!(
                     "{}({})",
@@ -97,6 +110,20 @@ impl TypeAst {
                         .collect::<Vec<String>>()
                         .join(", ")
                 )
+            }
+            TypeAst::Tuple { items, .. } => {
+                if items.is_empty() {
+                    "()".to_string()
+                } else {
+                    format!(
+                        "({})",
+                        items
+                            .iter()
+                            .map(|a| a.print_expr())
+                            .collect::<Vec<String>>()
+                            .join(", ")
+                    )
+                }
             }
             TypeAst::Record { fields, .. } => {
                 format!(
@@ -108,8 +135,27 @@ impl TypeAst {
                         .join(", ")
                 )
             }
-            TypeAst::Binary { lhs, op, rhs, .. } => {
-                format!("({} {} {})", lhs.print_expr(), op.symbol, rhs.print_expr())
+            TypeAst::Sum { variants, .. } => {
+                format!(
+                    "({})",
+                    variants
+                        .iter()
+                        .map(|t| t.print_expr())
+                        .collect::<Vec<String>>()
+                        .join(" | ")
+                )
+            }
+            TypeAst::Lambda { lhs, rhs, eff, .. } => {
+                if let Some(eff) = eff {
+                    format!(
+                        "({} -> {} ! {})",
+                        lhs.print_expr(),
+                        rhs.print_expr(),
+                        eff.print_expr()
+                    )
+                } else {
+                    format!("({} -> {})", lhs.print_expr(), rhs.print_expr())
+                }
             }
             TypeAst::Literal { value, .. } => value.pretty_print(),
         }
@@ -118,8 +164,8 @@ impl TypeAst {
     pub fn pretty_print(&self) -> String {
         match self {
             TypeAst::Identifier { name, .. } => name.clone(),
-            TypeAst::Constructor {
-                expr, params: args, ..
+            TypeAst::Application {
+                expr, args, ..
             } => {
                 format!(
                     "{}({})",
@@ -129,6 +175,20 @@ impl TypeAst {
                         .collect::<Vec<String>>()
                         .join(", ")
                 )
+            }
+            TypeAst::Tuple { items, .. } => {
+                if items.is_empty() {
+                    "()".to_string()
+                } else {
+                    format!(
+                        "({})",
+                        items
+                            .iter()
+                            .map(|a| a.pretty_print())
+                            .collect::<Vec<String>>()
+                            .join(", ")
+                    )
+                }
             }
             TypeAst::Record { fields, .. } => {
                 format!(
@@ -140,13 +200,27 @@ impl TypeAst {
                         .join(", ")
                 )
             }
-            TypeAst::Binary { lhs, op, rhs, .. } => {
+            TypeAst::Sum { variants, .. } => {
                 format!(
-                    "({} {} {})",
-                    lhs.pretty_print(),
-                    op.symbol,
-                    rhs.pretty_print()
+                    "({})",
+                    variants
+                        .iter()
+                        .map(|t| t.pretty_print())
+                        .collect::<Vec<String>>()
+                        .join(" | ")
                 )
+            }
+            TypeAst::Lambda { lhs, rhs, eff, .. } => {
+                if let Some(eff) = eff {
+                    format!(
+                        "({} -> {} ! {})",
+                        lhs.pretty_print(),
+                        rhs.pretty_print(),
+                        eff.pretty_print()
+                    )
+                } else {
+                    format!("({} -> {})", lhs.pretty_print(), rhs.pretty_print())
+                }
             }
             TypeAst::Literal { value, .. } => value.pretty_print(),
         }
@@ -158,28 +232,58 @@ impl PartialEq for TypeAst {
         match (self, other) {
             (Self::Identifier { name: l0, .. }, Self::Identifier { name: r0, .. }) => l0 == r0,
             (
-                Self::Constructor {
+                Self::Application {
                     expr: l0,
-                    params: l1,
+                    args: l1,
                     info: _,
                 },
-                Self::Constructor {
+                Self::Application {
                     expr: r0,
-                    params: r1,
+                    args: r1,
                     info: _,
                 },
             ) => l0 == r0 && l1 == r1,
             (
-                Self::Binary {
-                    lhs: l0,
-                    op: l1,
-                    rhs: l2,
+                Self::Tuple {
+                    items: l0,
                     info: _,
                 },
-                Self::Binary {
+                Self::Tuple {
+                    items: r0,
+                    info: _,
+                },
+            ) => l0 == r0,
+            (
+                Self::Record {
+                    fields: l0,
+                    info: _,
+                },
+                Self::Record {
+                    fields: r0,
+                    info: _,
+                },
+            ) => l0 == r0,
+            (
+                Self::Sum {
+                    variants: l0,
+                    info: _,
+                },
+                Self::Sum {
+                    variants: r0,
+                    info: _,
+                },
+            ) => l0 == r0,
+            (
+                Self::Lambda {
+                    lhs: l0,
+                    rhs: l1,
+                    eff: l2,
+                    info: _,
+                },
+                Self::Lambda {
                     lhs: r0,
-                    op: r1,
-                    rhs: r2,
+                    rhs: r1,
+                    eff: r2,
                     info: _,
                 },
             ) => l0 == r0 && l1 == r1 && l2 == r2,

--- a/lentoc/lib/src/type_checker/checker.rs
+++ b/lentoc/lib/src/type_checker/checker.rs
@@ -442,7 +442,7 @@ impl TypeChecker<'_> {
             },
             Ast::Tuple { exprs, info } => self.check_tuple(exprs, info)?,
             Ast::List { exprs: elems, info } => self.check_list(elems, info)?,
-            Ast::StaticVec { elem, len, info } => self.check_static_vec(elem, len, info)?,
+            Ast::Array { elem, len, info } => self.check_array(elem, len, info)?,
             Ast::Record { fields, info } => self.check_record(fields, info)?,
             Ast::MemberAccess {
                 expr: record,
@@ -768,7 +768,7 @@ impl TypeChecker<'_> {
         })
     }
 
-    fn check_static_vec(
+    fn check_array(
         &mut self,
         elem: &Ast,
         len: &Ast,
@@ -782,7 +782,7 @@ impl TypeChecker<'_> {
             } => n,
             _ => {
                 return Err(TypeError::new(
-                    "Static vector length must be a numeric literal".to_string(),
+                    "Array length must be a numeric literal".to_string(),
                     len.info().clone(),
                 )
                 .into())
@@ -790,7 +790,7 @@ impl TypeChecker<'_> {
         };
         let len = number_to_usize(&len_value).ok_or_else(|| {
             TypeErrorVariant::TypeError(TypeError::new(
-                "Static vector length must be a non-negative integer".to_string(),
+                "Array length must be a non-negative integer".to_string(),
                 len.info().clone(),
             ))
         })?;

--- a/lentoc/lib/src/type_checker/checker.rs
+++ b/lentoc/lib/src/type_checker/checker.rs
@@ -463,8 +463,11 @@ impl TypeChecker<'_> {
                 info,
             } => self.check_unary(op, operand, info)?,
             Ast::Let {
-                target, expr, info, ..
-            } => self.check_let(target, expr, info)?,
+                target,
+                expr,
+                annotation,
+                info,
+            } => self.check_let(target, expr, annotation, info)?,
             Ast::Block { exprs, info } => self.check_block(exprs, info)?,
             Ast::FunctionDecl {
                 name,
@@ -931,6 +934,7 @@ impl TypeChecker<'_> {
         &mut self,
         target: &BindPattern,
         expr: &Ast,
+        annotation: &Option<TypeAst>,
         info: &LineInfo,
     ) -> TypeCheckerResult<CheckedAst> {
         match target {
@@ -948,28 +952,31 @@ impl TypeChecker<'_> {
                 }
                 let expr = self.check_expr(expr)?;
                 let ty = expr.get_type().clone();
-                // if let Some(ty_ast) = annotation {
-                //     let expected_ty = self.check_type_expr(ty_ast)?;
-                //     if !ty.subtype(&expected_ty).success {
-                //         return Err(TypeError::new(
-                //             format!(
-                //                 "Cannot assign {} to {}",
-                //                 ty.pretty_print_color(),
-                //                 expected_ty.pretty_print_color()
-                //             ),
-                //             info.clone(),
-                //         )
-                //         .with_label(
-                //             format!("This is of type {}", ty.pretty_print_color()),
-                //             expr.info().clone(),
-                //         )
-                //         .with_label(
-                //             format!("This expected type {}", expected_ty.pretty_print_color()),
-                //             info.clone(),
-                //         )
-                //         .into());
-                //     }
-                // }
+                if let Some(ty_ast) = annotation {
+                    let expected_ty = self.check_type_expr(ty_ast)?;
+                    if !ty.subtype(&expected_ty).success {
+                        return Err(TypeError::new(
+                            format!(
+                                "Cannot assign {} to {}",
+                                ty.pretty_print_color(),
+                                expected_ty.pretty_print_color()
+                            ),
+                            info.clone(),
+                        )
+                        .with_label(
+                            format!("This is of type {}", ty.pretty_print_color()),
+                            expr.info().clone(),
+                        )
+                        .with_label(
+                            format!(
+                                "This expected type {}",
+                                expected_ty.pretty_print_color()
+                            ),
+                            info.clone(),
+                        )
+                        .into());
+                    }
+                }
                 self.add_variable(name.clone(), ty.clone());
                 Ok(CheckedAst::Let {
                     target: BindPattern::Variable {

--- a/lentoc/lib/src/type_checker/checker.rs
+++ b/lentoc/lib/src/type_checker/checker.rs
@@ -643,6 +643,10 @@ impl TypeChecker<'_> {
                 let elem_ty = self.check_type_expr(elem)?;
                 Type::Tuple(vec![elem_ty; *len])
             }
+            TypeAst::List { elem, .. } => {
+                let elem_ty = self.check_type_expr(elem)?;
+                Type::List(Box::new(elem_ty))
+            }
             TypeAst::Record { fields, .. } => {
                 let fields = fields
                     .iter()

--- a/lentoc/lib/src/type_checker/checker.rs
+++ b/lentoc/lib/src/type_checker/checker.rs
@@ -8,7 +8,6 @@ use crate::{
         ast::Ast,
         error::ParseError,
         op::{OpHandler, OpInfo, Operator, RuntimeOpHandler, StaticOpAst, StaticOpHandler},
-        parser::{FN_ARROW_SYM, SUM_TYPE_SYM},
         pattern::BindPattern,
     },
     util::error::{BaseError, BaseErrorExt, LineInfo},
@@ -519,7 +518,7 @@ impl TypeChecker<'_> {
                     TypeError::new(format!("Unknown type {}", name.clone().red()), info.clone())
                         .with_label("This type is not defined".to_string(), info.clone())
                 })?,
-            TypeAst::Constructor { expr, params, info } => {
+            TypeAst::Application { expr, args: params, info } => {
                 let expr_info = expr.info();
                 let Type::Alias(base_name, base_type) = self.check_type_expr(expr)? else {
                     return Err(TypeError::new(
@@ -541,6 +540,13 @@ impl TypeChecker<'_> {
                     .collect::<TypeCheckerResult<Vec<_>>>()?;
                 Type::Constructor(base_name, args, base_type)
             }
+            TypeAst::Tuple { items, .. } => {
+                let elems = items
+                    .iter()
+                    .map(|a| self.check_type_expr(a))
+                    .collect::<TypeCheckerResult<Vec<_>>>()?;
+                Type::Tuple(elems)
+            }
             TypeAst::Record { fields, .. } => {
                 let fields = fields
                     .iter()
@@ -548,34 +554,22 @@ impl TypeChecker<'_> {
                     .collect::<TypeCheckerResult<Vec<_>>>()?;
                 Type::Record(fields)
             }
-            TypeAst::Binary { lhs, op, rhs, info } => {
+            TypeAst::Sum { variants, .. } => {
+                let variants = variants
+                    .iter()
+                    .map(|v| self.check_type_expr(v))
+                    .collect::<TypeCheckerResult<Vec<_>>>()?;
+                Type::Sum(variants).simplify()
+            }
+            TypeAst::Lambda { lhs, rhs, .. } => {
                 let lhs_ty = self.check_type_expr(lhs)?;
                 let rhs_ty = self.check_type_expr(rhs)?;
-                match op.symbol.as_str() {
-                    SUM_TYPE_SYM => Type::Sum(vec![lhs_ty, rhs_ty]).simplify(),
-                    FN_ARROW_SYM => Type::Function(Box::new(FunctionType::new(
-                        CheckedParam::from_str("_", lhs_ty),
-                        rhs_ty,
-                    ))),
-                    _ => {
-                        return Err(TypeError::new(
-                            format!("Unsupported type operator {}", op.symbol),
-                            info.clone(),
-                        )
-                        .into())
-                    }
-                }
+                Type::Function(Box::new(FunctionType::new(
+                    CheckedParam::from_str("_", lhs_ty),
+                    rhs_ty,
+                )))
             }
-            TypeAst::Literal { value, info } => match value {
-                Value::Type(ty) => ty.clone(),
-                _ => {
-                    return Err(TypeError::new(
-                        format!("Invalid literal in type position: {}", value.pretty_print()),
-                        info.clone(),
-                    )
-                    .into())
-                }
-            },
+            TypeAst::Literal { value, .. } => value.get_type().clone(),
         })
     }
 

--- a/lentoc/lib/src/type_checker/checker.rs
+++ b/lentoc/lib/src/type_checker/checker.rs
@@ -3,7 +3,10 @@ use super::{
     types::{std_types, FunctionType, GetType, Type, TypeTrait},
 };
 use crate::{
-    interpreter::value::{RecordKey, Value},
+    interpreter::{
+        number::{Number, UnsignedInteger},
+        value::{RecordKey, Value},
+    },
     parser::{
         ast::Ast,
         error::ParseError,
@@ -91,6 +94,9 @@ struct TypeEnv {
     // The type environment
     types: HashMap<String, Type>,
 
+    // Type declaration parameters by alias name
+    type_params: HashMap<String, Vec<String>>,
+
     // The operators environment
     operators: Vec<Operator>,
 }
@@ -116,6 +122,17 @@ impl TypeEnv {
     // Add a type to the type environment
     pub fn add_type(&mut self, name: &str, ty: Type) {
         self.types.insert(name.to_string(), ty);
+    }
+
+    pub fn add_type_with_params(&mut self, name: &str, ty: Type, params: Vec<String>) {
+        self.types.insert(name.to_string(), ty);
+        if !params.is_empty() {
+            self.type_params.insert(name.to_string(), params);
+        }
+    }
+
+    pub fn lookup_type_params(&self, name: &str) -> Option<&[String]> {
+        self.type_params.get(name).map(Vec::as_slice)
     }
 
     // Add a variable to the type environment
@@ -154,6 +171,10 @@ impl TypeChecker<'_> {
         self.env.add_type(name, ty);
     }
 
+    pub fn add_type_with_params(&mut self, name: &str, ty: Type, params: Vec<String>) {
+        self.env.add_type_with_params(name, ty, params);
+    }
+
     pub fn add_operator(&mut self, op: Operator) {
         self.env.add_operator(op);
     }
@@ -189,6 +210,12 @@ impl TypeChecker<'_> {
         self.env
             .lookup_type(name)
             .or_else(|| self.parent.and_then(|p| p.lookup_type(name)))
+    }
+
+    fn lookup_type_params(&self, name: &str) -> Option<&[String]> {
+        self.env
+            .lookup_type_params(name)
+            .or_else(|| self.parent.and_then(|p| p.lookup_type_params(name)))
     }
 
     fn lookup_identifier(&self, name: &str) -> Option<IdentifierType> {
@@ -330,9 +357,29 @@ impl TypeChecker<'_> {
                 self.env.add_variable(name.clone(), sig_type);
                 continue;
             }
-            if let Ast::TypeDecl { name, .. } = e {
+            if let Ast::TypeDecl {
+                name, params, body, ..
+            } = e
+            {
                 // Register type name as a variable (type-level binding)
                 self.env.add_variable(name.clone(), std_types::TYPE.clone());
+
+                let mut type_scope = self.new_scope();
+                type_scope.add_type("Self", Type::Variable(name.clone().into()));
+                let mut param_names = Vec::new();
+                for p in params {
+                    let Ast::Identifier { name: param_name, .. } = p else {
+                        continue;
+                    };
+                    param_names.push(param_name.clone());
+                    type_scope.add_type(param_name, Type::Variable(param_name.clone().into()));
+                }
+                let body_ty = type_scope.check_type_expr(body)?;
+                self.env.add_type_with_params(
+                    name,
+                    Type::Alias(name.clone().into(), Box::new(body_ty)),
+                    param_names,
+                );
                 continue;
             }
             if let Ast::Let { target, expr, .. } = e {
@@ -395,6 +442,7 @@ impl TypeChecker<'_> {
             },
             Ast::Tuple { exprs, info } => self.check_tuple(exprs, info)?,
             Ast::List { exprs: elems, info } => self.check_list(elems, info)?,
+            Ast::StaticVec { elem, len, info } => self.check_static_vec(elem, len, info)?,
             Ast::Record { fields, info } => self.check_record(fields, info)?,
             Ast::MemberAccess {
                 expr: record,
@@ -499,9 +547,20 @@ impl TypeChecker<'_> {
                 }
             }
             Ast::TypeDecl {
-                name, body, info, ..
+                name,
+                params,
+                body,
+                info,
             } => {
-                let _ = self.check_type_expr(body)?;
+                let mut type_scope = self.new_scope();
+                type_scope.add_type("Self", Type::Variable(name.clone().into()));
+                for p in params {
+                    let Ast::Identifier { name: param_name, .. } = p else {
+                        continue;
+                    };
+                    type_scope.add_type(param_name, Type::Variable(param_name.clone().into()));
+                }
+                let _ = type_scope.check_type_expr(body)?;
                 CheckedAst::TypeDecl {
                     name: name.clone(),
                     info: info.clone(),
@@ -538,7 +597,40 @@ impl TypeChecker<'_> {
                     .iter()
                     .map(|a| self.check_type_expr(a))
                     .collect::<TypeCheckerResult<Vec<_>>>()?;
-                Type::Constructor(base_name, args, base_type)
+
+                let param_names = self.lookup_type_params(&base_name.to_string()).unwrap_or(&[]);
+                if !param_names.is_empty() {
+                    if args.len() != param_names.len() {
+                        return Err(TypeError::new(
+                            format!(
+                                "Type {} expects {} argument(s), found {}",
+                                base_name,
+                                param_names.len(),
+                                args.len()
+                            ),
+                            info.clone(),
+                        )
+                        .with_label(
+                            format!(
+                                "Expected {} type argument(s) for {}",
+                                param_names.len(),
+                                base_name
+                            ),
+                            expr_info.clone(),
+                        )
+                        .into());
+                    }
+                    let judgements = param_names
+                        .iter()
+                        .cloned()
+                        .zip(args.iter().cloned())
+                        .map(|(name, ty)| (name.into(), ty))
+                        .collect();
+                    let mut changed = false;
+                    base_type.specialize(&judgements, &mut changed)
+                } else {
+                    Type::Constructor(base_name, args, base_type)
+                }
             }
             TypeAst::Tuple { items, .. } => {
                 let elems = items
@@ -547,6 +639,10 @@ impl TypeChecker<'_> {
                     .collect::<TypeCheckerResult<Vec<_>>>()?;
                 Type::Tuple(elems)
             }
+            TypeAst::StaticVector { elem, len, .. } => {
+                let elem_ty = self.check_type_expr(elem)?;
+                Type::Tuple(vec![elem_ty; *len])
+            }
             TypeAst::Record { fields, .. } => {
                 let fields = fields
                     .iter()
@@ -554,6 +650,7 @@ impl TypeChecker<'_> {
                     .collect::<TypeCheckerResult<Vec<_>>>()?;
                 Type::Record(fields)
             }
+            TypeAst::Refinement { base, .. } => self.check_type_expr(base)?,
             TypeAst::Sum { variants, .. } => {
                 let variants = variants
                     .iter()
@@ -667,6 +764,43 @@ impl TypeChecker<'_> {
         Ok(CheckedAst::List {
             exprs: checked_elems,
             ty: Type::List(Box::new(list_type)),
+            info: info.clone(),
+        })
+    }
+
+    fn check_static_vec(
+        &mut self,
+        elem: &Ast,
+        len: &Ast,
+        info: &LineInfo,
+    ) -> TypeCheckerResult<CheckedAst> {
+        let len_checked = self.check_expr(len)?;
+        let len_value = match len_checked {
+            CheckedAst::Literal {
+                value: Value::Number(n),
+                ..
+            } => n,
+            _ => {
+                return Err(TypeError::new(
+                    "Static vector length must be a numeric literal".to_string(),
+                    len.info().clone(),
+                )
+                .into())
+            }
+        };
+        let len = number_to_usize(&len_value).ok_or_else(|| {
+            TypeErrorVariant::TypeError(TypeError::new(
+                "Static vector length must be a non-negative integer".to_string(),
+                len.info().clone(),
+            ))
+        })?;
+
+        let checked_elem = self.check_expr(elem)?;
+        let elem_ty = checked_elem.get_type().clone();
+        let exprs = vec![checked_elem; len];
+        Ok(CheckedAst::List {
+            exprs,
+            ty: Type::List(Box::new(elem_ty)),
             info: info.clone(),
         })
     }
@@ -1334,4 +1468,19 @@ fn binding_typed_names(pattern: &BindPattern, ty: &Type) -> HashSet<(String, Typ
     let mut names = HashSet::new();
     visit(pattern, ty, &mut names);
     names
+}
+
+fn number_to_usize(n: &Number) -> Option<usize> {
+    match n {
+        Number::UnsignedInteger(u) => match u {
+            UnsignedInteger::UInt1(v) => Some((*v).into()),
+            UnsignedInteger::UInt8(v) => Some((*v).into()),
+            UnsignedInteger::UInt16(v) => Some((*v).into()),
+            UnsignedInteger::UInt32(v) => usize::try_from(*v).ok(),
+            UnsignedInteger::UInt64(v) => usize::try_from(*v).ok(),
+            UnsignedInteger::UInt128(v) => usize::try_from(*v).ok(),
+            UnsignedInteger::UIntVar(v) => v.to_string().parse::<usize>().ok(),
+        },
+        _ => None,
+    }
 }

--- a/lentoc/lib/src/type_checker/checker.rs
+++ b/lentoc/lib/src/type_checker/checker.rs
@@ -639,7 +639,7 @@ impl TypeChecker<'_> {
                     .collect::<TypeCheckerResult<Vec<_>>>()?;
                 Type::Tuple(elems)
             }
-            TypeAst::StaticVector { elem, len, .. } => {
+            TypeAst::Array { elem, len, .. } => {
                 let elem_ty = self.check_type_expr(elem)?;
                 Type::Tuple(vec![elem_ty; *len])
             }

--- a/lentoc/lib/src/type_checker/specialize.rs
+++ b/lentoc/lib/src/type_checker/specialize.rs
@@ -608,7 +608,7 @@ pub fn is_type_expr(expr: &Ast, types: &HashSet<String>) -> bool {
                 && is_type_expr(rhs, types)
         }
         Ast::List { exprs, .. } if exprs.len() == 1 => is_type_expr(&exprs[0], types),
-        Ast::StaticVec { elem, len, .. } => {
+        Ast::Array { elem, len, .. } => {
             is_type_expr(elem, types) && matches!(**len, Ast::Literal { .. })
         }
         Ast::Literal { .. } => true,
@@ -644,9 +644,9 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
                 info: info.clone(),
             })
         }
-        Ast::StaticVec { elem, len, info } => {
+        Ast::Array { elem, len, info } => {
             let elem = into_type_ast(*elem)?;
-            let len = static_vec_len_from_ast(*len)?;
+            let len = array_len_from_ast(*len)?;
             Ok(TypeAst::Array {
                 elem: Box::new(elem),
                 len,
@@ -827,23 +827,23 @@ fn try_into_refinement(
     }))
 }
 
-fn static_vec_len_from_ast(ast: Ast) -> Result<usize, ParseError> {
+fn array_len_from_ast(ast: Ast) -> Result<usize, ParseError> {
     let info = ast.info().clone();
     let Ast::Literal { value, .. } = ast else {
         return Err(ParseError::new(
-            "Expected static vector length to be an integer literal".to_string(),
+            "Expected array length to be an integer literal".to_string(),
             info,
         ));
     };
     let crate::interpreter::value::Value::Number(n) = value else {
         return Err(ParseError::new(
-            "Expected static vector length to be a numeric literal".to_string(),
+            "Expected array length to be a numeric literal".to_string(),
             info,
         ));
     };
     number_to_usize(&n).ok_or_else(|| {
         ParseError::new(
-            "Expected static vector length to be a non-negative integer".to_string(),
+            "Expected array length to be a non-negative integer".to_string(),
             info,
         )
     })

--- a/lentoc/lib/src/type_checker/specialize.rs
+++ b/lentoc/lib/src/type_checker/specialize.rs
@@ -751,20 +751,6 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
             info,
         )),
         Ast::Block { exprs, info } => {
-            if exprs.len() == 2 {
-                let base_result = into_type_ast(exprs[0].clone());
-                let pred_result = into_type_ast(exprs[1].clone());
-                if let Ok(base) = base_result {
-                    if pred_result.is_err() {
-                        return Ok(TypeAst::Refinement {
-                            binder: RecordKey::String("_".to_string()),
-                            base: Box::new(base),
-                            predicate: Box::new(exprs[1].clone()),
-                            info,
-                        });
-                    }
-                }
-            }
             let mut items = Vec::new();
             for expr in exprs {
                 items.push(into_type_ast(expr)?);
@@ -772,9 +758,6 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
             if items.len() == 1 {
                 Ok(items.remove(0))
             } else {
-                // A block with multiple type expressions could also
-                // represent a TypeAst::Refinement if the items form a
-                // base-type-and-predicate shape.
                 Ok(TypeAst::Tuple { items, info })
             }
         }

--- a/lentoc/lib/src/type_checker/specialize.rs
+++ b/lentoc/lib/src/type_checker/specialize.rs
@@ -3,7 +3,10 @@ use crate::{
         ast::Ast,
         error::ParseError,
         op::OpInfo,
-        parser::{ParseResult, ASSIGNMENT_SYM, COMMA_SYM, FN_ARROW_SYM, SUM_TYPE_SYM},
+        parser::{
+            ParseResult, ASSIGNMENT_SYM, COMMA_SYM, EFFECT_ASCRIPTION_SYM, FN_ARROW_SYM,
+            SUM_TYPE_SYM,
+        },
         pattern::BindPattern,
     },
     type_checker::checked_ast::{ParamAst, TypeAst},
@@ -25,7 +28,7 @@ use std::collections::HashSet;
 /// - `f(x, y) = b` into `Assignment { target: BindPattern::Function { name: f, params: [x, y] }, expr: b }`
 /// - `f x, y = b` into `Assignment { target: BindPattern::Function { name: f, params: [x, y] }, expr: b }`
 /// - `int f str x, bool y = b` into `Assignment { annotation: Some(int), target: BindPattern::Function { name: f, params: [str x, bool y] }, expr: b }`
-/// - `List int` into `LiteralType { expr: TypeAst::Constructor { expr: List }, args: [int] }`
+/// - `List int` into `LiteralType { expr: TypeAst::Application { expr: List }, args: [int] }`
 pub fn top(expr: Ast, types: &HashSet<String>, variables: Option<&HashSet<String>>) -> ParseResult {
     match expr {
         // Specialize type constructors to literal types
@@ -549,12 +552,12 @@ pub fn try_type_annotation(
         let last_info = params
             .last()
             .map_or(constructor_info.clone(), |p| p.info().clone());
-        let type_expr = TypeAst::Constructor {
+        let type_expr = TypeAst::Application {
             expr: Box::new(TypeAst::Identifier {
                 name: constructor_name.clone(),
                 info: constructor_info.clone(),
             }),
-            params,
+            args: params,
             info: constructor_info.join(&last_info),
         };
         // Remove the type annotation expressions from the list
@@ -596,12 +599,14 @@ pub fn is_type_expr(expr: &Ast, types: &HashSet<String>) -> bool {
         Ast::Identifier { name, .. } => types.contains(name),
         // Sum types like `int | str`
         Ast::Binary { lhs, op, rhs, .. } => {
-            (op.symbol == SUM_TYPE_SYM || op.symbol == FN_ARROW_SYM)
+            (op.symbol == SUM_TYPE_SYM
+                || op.symbol == FN_ARROW_SYM
+                || op.symbol == EFFECT_ASCRIPTION_SYM)
                 && is_type_expr(lhs, types)
                 && is_type_expr(rhs, types)
         }
         Ast::List { exprs, .. } if exprs.len() == 1 => is_type_expr(&exprs[0], types),
-        Ast::Literal { .. } => false,
+        Ast::Literal { .. } => true,
         Ast::FunctionCall { expr, arg, .. } => {
             is_type_expr(expr, types) && is_type_expr(arg, types)
         }
@@ -625,14 +630,21 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
         }),
         Ast::List { mut exprs, info } if exprs.len() == 1 => {
             let inner = into_type_ast(exprs.remove(0))?;
-            Ok(TypeAst::Constructor {
+            Ok(TypeAst::Application {
                 expr: Box::new(TypeAst::Identifier {
                     name: "List".to_string(),
                     info: info.clone(),
                 }),
-                params: vec![inner],
+                args: vec![inner],
                 info: info.clone(),
             })
+        }
+        Ast::Tuple { exprs, info } => {
+            let items = exprs
+                .into_iter()
+                .map(into_type_ast)
+                .collect::<Result<Vec<_>, ParseError>>()?;
+            Ok(TypeAst::Tuple { items, info })
         }
         Ast::Record { fields, info } => {
             let fields = fields
@@ -642,34 +654,130 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
             Ok(TypeAst::Record { fields, info })
         }
         Ast::FunctionCall { expr, arg, info } => {
-            let mut params = vec![into_type_ast(*arg)?];
+            let mut params = Vec::new();
+            match *arg {
+                Ast::Tuple { exprs, .. } => {
+                    for arg_expr in exprs {
+                        params.push(into_type_ast(arg_expr)?);
+                    }
+                }
+                arg => params.push(into_type_ast(arg)?),
+            }
             let mut head = *expr;
             while let Ast::FunctionCall { expr, arg, .. } = head {
-                params.push(into_type_ast(*arg)?);
+                match *arg {
+                    Ast::Tuple { exprs, .. } => {
+                        for arg_expr in exprs.into_iter().rev() {
+                            params.push(into_type_ast(arg_expr)?);
+                        }
+                    }
+                    arg => params.push(into_type_ast(arg)?),
+                }
                 head = *expr;
             }
             params.reverse();
             let head = into_type_ast(head)?;
-            Ok(TypeAst::Constructor {
+            Ok(TypeAst::Application {
                 expr: Box::new(head),
-                params,
+                args: params,
                 info,
             })
         }
-        Ast::Binary { lhs, op, rhs, info }
-            if op.symbol == SUM_TYPE_SYM || op.symbol == FN_ARROW_SYM =>
-        {
-            Ok(TypeAst::Binary {
-                lhs: Box::new(into_type_ast(*lhs)?),
-                op,
-                rhs: Box::new(into_type_ast(*rhs)?),
+        Ast::Binary { lhs, op, rhs, info } if op.symbol == SUM_TYPE_SYM => {
+            let lhs = into_type_ast(*lhs)?;
+            let rhs = into_type_ast(*rhs)?;
+            let mut variants = Vec::new();
+            match lhs {
+                TypeAst::Sum { variants: lhs, .. } => variants.extend(lhs),
+                lhs => variants.push(lhs),
+            }
+            match rhs {
+                TypeAst::Sum { variants: rhs, .. } => variants.extend(rhs),
+                rhs => variants.push(rhs),
+            }
+            Ok(TypeAst::Sum { variants, info })
+        }
+        Ast::Binary { lhs, op, rhs, info } if op.symbol == FN_ARROW_SYM => {
+            let mut eff = None;
+
+            let lhs = match *lhs {
+                Ast::Binary {
+                    lhs: eff_lhs,
+                    op: eff_op,
+                    rhs: eff_rhs,
+                    ..
+                } if eff_op.symbol == EFFECT_ASCRIPTION_SYM => {
+                    eff = Some(Box::new(into_effect_ast(*eff_rhs)?));
+                    into_type_ast(*eff_lhs)?
+                }
+                lhs => into_type_ast(lhs)?,
+            };
+
+            let rhs = match *rhs {
+                Ast::Binary {
+                    lhs: eff_lhs,
+                    op: eff_op,
+                    rhs: eff_rhs,
+                    ..
+                } if eff_op.symbol == EFFECT_ASCRIPTION_SYM => {
+                    eff = Some(Box::new(into_effect_ast(*eff_rhs)?));
+                    into_type_ast(*eff_lhs)?
+                }
+                rhs => into_type_ast(rhs)?,
+            };
+
+            Ok(TypeAst::Lambda {
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
+                eff,
                 info,
             })
+        }
+        Ast::Binary { op, info, .. } if op.symbol == EFFECT_ASCRIPTION_SYM => Err(ParseError::new(
+            "Effect ascription is only valid on function types".to_string(),
+            info,
+        )),
+        Ast::Block { exprs, info } => {
+            let mut items = Vec::new();
+            for expr in exprs {
+                items.push(into_type_ast(expr)?);
+            }
+            if items.len() == 1 {
+                Ok(items.remove(0))
+            } else {
+                Ok(TypeAst::Tuple { items, info })
+            }
+        }
+        Ast::Literal { value, info } => {
+            if matches!(value, crate::interpreter::value::Value::Type(_)) {
+                return Err(ParseError::new(
+                    "Expected a value literal singleton type, found a type literal".to_string(),
+                    info,
+                ));
+            }
+            Ok(TypeAst::Literal { value, info })
         }
         _ => Err(ParseError::new(
             format!("Expected a type expression, found: {}", expr.print_expr()),
             expr.info().clone(),
         )),
+    }
+}
+
+fn into_effect_ast(effect_expr: Ast) -> Result<TypeAst, ParseError> {
+    match effect_expr {
+        Ast::Block { exprs, info } => {
+            let mut items = Vec::new();
+            for expr in exprs {
+                items.push(into_type_ast(expr)?);
+            }
+            if items.len() == 1 {
+                Ok(items.remove(0))
+            } else {
+                Ok(TypeAst::Tuple { items, info })
+            }
+        }
+        expr => into_type_ast(expr),
     }
 }
 

--- a/lentoc/lib/src/type_checker/specialize.rs
+++ b/lentoc/lib/src/type_checker/specialize.rs
@@ -608,7 +608,9 @@ pub fn is_type_expr(expr: &Ast, types: &HashSet<String>) -> bool {
                 && is_type_expr(rhs, types)
         }
         Ast::List { exprs, .. } if exprs.len() == 1 => is_type_expr(&exprs[0], types),
-        Ast::StaticVec { elem, len, .. } => is_type_expr(elem, types) && matches!(**len, Ast::Literal { .. }),
+        Ast::StaticVec { elem, len, .. } => {
+            is_type_expr(elem, types) && matches!(**len, Ast::Literal { .. })
+        }
         Ast::Literal { .. } => true,
         Ast::FunctionCall { expr, arg, .. } => {
             is_type_expr(expr, types) && is_type_expr(arg, types)
@@ -645,7 +647,7 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
         Ast::StaticVec { elem, len, info } => {
             let elem = into_type_ast(*elem)?;
             let len = static_vec_len_from_ast(*len)?;
-            Ok(TypeAst::StaticVector {
+            Ok(TypeAst::Array {
                 elem: Box::new(elem),
                 len,
                 info,

--- a/lentoc/lib/src/type_checker/specialize.rs
+++ b/lentoc/lib/src/type_checker/specialize.rs
@@ -11,7 +11,7 @@ use crate::{
         },
         pattern::BindPattern,
     },
-    type_checker::checked_ast::{ParamAst, TypeAst},
+    type_checker::checked_ast::{Effect, ParamAst, TypeAst},
     util::error::{BaseErrorExt, LineInfo},
 };
 use colorful::Colorful;
@@ -717,7 +717,7 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
             // effect is always on the rhs of the arrow; a `!` on the lhs
             // would be `(A ! IO) -> B`, which is semantically invalid
             // (input types do not have effects).
-            let mut eff = None;
+            let mut eff = vec![];
 
             let lhs = into_type_ast(*lhs)?;
 
@@ -728,7 +728,7 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
                     rhs: eff_rhs,
                     ..
                 } if eff_op.symbol == EFFECT_ASCRIPTION_SYM => {
-                    eff = Some(Box::new(into_effect_ast(*eff_rhs)?));
+                    eff = into_effect_ast(*eff_rhs)?;
                     into_type_ast(*eff_lhs)?
                 }
                 rhs => into_type_ast(rhs)?,
@@ -772,20 +772,32 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
     }
 }
 
-fn into_effect_ast(effect_expr: Ast) -> Result<TypeAst, ParseError> {
+fn into_effect_ast(effect_expr: Ast) -> Result<Vec<Effect>, ParseError> {
     match effect_expr {
-        Ast::Block { exprs, info } => {
-            let mut items = Vec::new();
-            for expr in exprs {
-                items.push(into_type_ast(expr)?);
-            }
-            if items.len() == 1 {
-                Ok(items.remove(0))
-            } else {
-                Ok(TypeAst::Tuple { items, info })
-            }
+        Ast::Identifier { name, info: _ } => {
+            Ok(vec![Effect { name, params: vec![] }])
         }
-        expr => into_type_ast(expr),
+        Ast::Tuple { exprs, info: _ } => {
+            let mut effects = Vec::new();
+            for expr in exprs {
+                effects.extend(into_effect_ast(expr)?);
+            }
+            Ok(effects)
+        }
+        Ast::Block { exprs, info: _ } => {
+            // { IO } -> single effect
+            // { IO, File } -> block containing a single tuple: Tuple([IO, File])
+            // { IO; File } -> block with multiple exprs (semicolon-separated)
+            let mut effects = Vec::new();
+            for expr in exprs {
+                effects.extend(into_effect_ast(expr)?);
+            }
+            Ok(effects)
+        }
+        _ => Err(ParseError::new(
+            "Expected an effect expression".to_string(),
+            effect_expr.info().clone(),
+        )),
     }
 }
 

--- a/lentoc/lib/src/type_checker/specialize.rs
+++ b/lentoc/lib/src/type_checker/specialize.rs
@@ -711,20 +711,15 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
             Ok(TypeAst::Sum { variants, info })
         }
         Ast::Binary { lhs, op, rhs, info } if op.symbol == FN_ARROW_SYM => {
+            // Effect ascription attaches to the return side:
+            //   `A -> B ! IO`  parses as  `A -> (B ! IO)`
+            // The `!` binds tighter than `->` (prec 750 vs 650), so the
+            // effect is always on the rhs of the arrow; a `!` on the lhs
+            // would be `(A ! IO) -> B`, which is semantically invalid
+            // (input types do not have effects).
             let mut eff = None;
 
-            let lhs = match *lhs {
-                Ast::Binary {
-                    lhs: eff_lhs,
-                    op: eff_op,
-                    rhs: eff_rhs,
-                    ..
-                } if eff_op.symbol == EFFECT_ASCRIPTION_SYM => {
-                    eff = Some(Box::new(into_effect_ast(*eff_rhs)?));
-                    into_type_ast(*eff_lhs)?
-                }
-                lhs => into_type_ast(lhs)?,
-            };
+            let lhs = into_type_ast(*lhs)?;
 
             let rhs = match *rhs {
                 Ast::Binary {

--- a/lentoc/lib/src/type_checker/specialize.rs
+++ b/lentoc/lib/src/type_checker/specialize.rs
@@ -751,6 +751,20 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
             info,
         )),
         Ast::Block { exprs, info } => {
+            if exprs.len() == 2 {
+                let base_result = into_type_ast(exprs[0].clone());
+                let pred_result = into_type_ast(exprs[1].clone());
+                if let Ok(base) = base_result {
+                    if pred_result.is_err() {
+                        return Ok(TypeAst::Refinement {
+                            binder: RecordKey::String("_".to_string()),
+                            base: Box::new(base),
+                            predicate: Box::new(exprs[1].clone()),
+                            info,
+                        });
+                    }
+                }
+            }
             let mut items = Vec::new();
             for expr in exprs {
                 items.push(into_type_ast(expr)?);
@@ -758,6 +772,9 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
             if items.len() == 1 {
                 Ok(items.remove(0))
             } else {
+                // A block with multiple type expressions could also
+                // represent a TypeAst::Refinement if the items form a
+                // base-type-and-predicate shape.
                 Ok(TypeAst::Tuple { items, info })
             }
         }

--- a/lentoc/lib/src/type_checker/specialize.rs
+++ b/lentoc/lib/src/type_checker/specialize.rs
@@ -1,4 +1,6 @@
 use crate::{
+    interpreter::number::{Number, UnsignedInteger},
+    interpreter::value::RecordKey,
     parser::{
         ast::Ast,
         error::ParseError,
@@ -606,6 +608,7 @@ pub fn is_type_expr(expr: &Ast, types: &HashSet<String>) -> bool {
                 && is_type_expr(rhs, types)
         }
         Ast::List { exprs, .. } if exprs.len() == 1 => is_type_expr(&exprs[0], types),
+        Ast::StaticVec { elem, len, .. } => is_type_expr(elem, types) && matches!(**len, Ast::Literal { .. }),
         Ast::Literal { .. } => true,
         Ast::FunctionCall { expr, arg, .. } => {
             is_type_expr(expr, types) && is_type_expr(arg, types)
@@ -639,6 +642,15 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
                 info: info.clone(),
             })
         }
+        Ast::StaticVec { elem, len, info } => {
+            let elem = into_type_ast(*elem)?;
+            let len = static_vec_len_from_ast(*len)?;
+            Ok(TypeAst::StaticVector {
+                elem: Box::new(elem),
+                len,
+                info,
+            })
+        }
         Ast::Tuple { exprs, info } => {
             let items = exprs
                 .into_iter()
@@ -647,6 +659,9 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
             Ok(TypeAst::Tuple { items, info })
         }
         Ast::Record { fields, info } => {
+            if let Some(refinement) = try_into_refinement(&fields, &info)? {
+                return Ok(refinement);
+            }
             let fields = fields
                 .into_iter()
                 .map(|(key, value)| Ok((key, into_type_ast(value)?)))
@@ -778,6 +793,72 @@ fn into_effect_ast(effect_expr: Ast) -> Result<TypeAst, ParseError> {
             }
         }
         expr => into_type_ast(expr),
+    }
+}
+
+fn try_into_refinement(
+    fields: &[(RecordKey, Ast)],
+    info: &LineInfo,
+) -> Result<Option<TypeAst>, ParseError> {
+    if fields.len() != 1 {
+        return Ok(None);
+    }
+    let (binder, field_ty) = &fields[0];
+    let Ast::Binary { lhs, op, rhs, .. } = field_ty else {
+        return Ok(None);
+    };
+    if op.symbol != SUM_TYPE_SYM {
+        return Ok(None);
+    }
+    let base_is_type = matches!(into_type_ast((**lhs).clone()), Ok(_));
+    let pred_is_type = matches!(into_type_ast((**rhs).clone()), Ok(_));
+    if !base_is_type || pred_is_type {
+        return Ok(None);
+    }
+
+    let base = into_type_ast((**lhs).clone())?;
+    Ok(Some(TypeAst::Refinement {
+        binder: binder.clone(),
+        base: Box::new(base),
+        predicate: Box::new((**rhs).clone()),
+        info: info.clone(),
+    }))
+}
+
+fn static_vec_len_from_ast(ast: Ast) -> Result<usize, ParseError> {
+    let info = ast.info().clone();
+    let Ast::Literal { value, .. } = ast else {
+        return Err(ParseError::new(
+            "Expected static vector length to be an integer literal".to_string(),
+            info,
+        ));
+    };
+    let crate::interpreter::value::Value::Number(n) = value else {
+        return Err(ParseError::new(
+            "Expected static vector length to be a numeric literal".to_string(),
+            info,
+        ));
+    };
+    number_to_usize(&n).ok_or_else(|| {
+        ParseError::new(
+            "Expected static vector length to be a non-negative integer".to_string(),
+            info,
+        )
+    })
+}
+
+fn number_to_usize(n: &Number) -> Option<usize> {
+    match n {
+        Number::UnsignedInteger(u) => match u {
+            UnsignedInteger::UInt1(v) => Some((*v).into()),
+            UnsignedInteger::UInt8(v) => Some((*v).into()),
+            UnsignedInteger::UInt16(v) => Some((*v).into()),
+            UnsignedInteger::UInt32(v) => usize::try_from(*v).ok(),
+            UnsignedInteger::UInt64(v) => usize::try_from(*v).ok(),
+            UnsignedInteger::UInt128(v) => usize::try_from(*v).ok(),
+            UnsignedInteger::UIntVar(v) => v.to_string().parse::<usize>().ok(),
+        },
+        _ => None,
     }
 }
 

--- a/lentoc/lib/src/type_checker/specialize.rs
+++ b/lentoc/lib/src/type_checker/specialize.rs
@@ -634,13 +634,9 @@ pub fn into_type_ast(expr: Ast) -> Result<TypeAst, ParseError> {
             info: info.clone(),
         }),
         Ast::List { mut exprs, info } if exprs.len() == 1 => {
-            let inner = into_type_ast(exprs.remove(0))?;
-            Ok(TypeAst::Application {
-                expr: Box::new(TypeAst::Identifier {
-                    name: "List".to_string(),
-                    info: info.clone(),
-                }),
-                args: vec![inner],
+            let elem = into_type_ast(exprs.remove(0))?;
+            Ok(TypeAst::List {
+                elem: Box::new(elem),
                 info: info.clone(),
             })
         }

--- a/lentoc/lib/src/type_checker/tests.rs
+++ b/lentoc/lib/src/type_checker/tests.rs
@@ -186,7 +186,7 @@ mod tests {
 
     #[test]
     fn checked_let_with_type_annotation() {
-        let result = check_str_one("let x: int = 5", Some(&stdlib())).unwrap();
+        let result = check_str_one("let x: u8 = 5", Some(&stdlib())).unwrap();
         assert!(matches!(result, CheckedAst::Let { .. }));
     }
 
@@ -199,8 +199,14 @@ mod tests {
     #[test]
     fn checked_let_with_tuple_type_annotation() {
         let result =
-            check_str_one("let pair: (int, bool) = (1, true)", Some(&stdlib())).unwrap();
+            check_str_one("let pair: (u1, bool) = (1, true)", Some(&stdlib())).unwrap();
         assert!(matches!(result, CheckedAst::Let { .. }));
+    }
+
+    #[test]
+    fn checked_let_type_mismatch_rejected() {
+        let result = check_str_one("let x: bool = 5", Some(&stdlib()));
+        assert!(result.is_err());
     }
 
     #[test]

--- a/lentoc/lib/src/type_checker/tests.rs
+++ b/lentoc/lib/src/type_checker/tests.rs
@@ -210,6 +210,12 @@ mod tests {
     }
 
     #[test]
+    fn checked_let_supertype_int() {
+        let result = check_str_one("let x: int = 2", Some(&stdlib())).unwrap();
+        assert!(matches!(result, CheckedAst::Let { .. }));
+    }
+
+    #[test]
     fn checked_function_def_has_all_params() {
         let result = check_str_one("fn add(x, y) = 1", Some(&stdlib())).unwrap();
         if let CheckedAst::FunctionDef { params, .. } = result {

--- a/lentoc/lib/src/type_checker/tests.rs
+++ b/lentoc/lib/src/type_checker/tests.rs
@@ -230,4 +230,17 @@ mod tests {
         let result = check_str_one("let x = 1", Some(&stdlib())).unwrap();
         assert!(matches!(result, CheckedAst::Let { .. }));
     }
+
+    #[test]
+    fn checked_type_decl_literal_sum() {
+        let result = check_str_one("type FewNums = 5 | 6 | 7", Some(&stdlib())).unwrap();
+        assert!(matches!(result, CheckedAst::TypeDecl { .. }));
+    }
+
+    #[test]
+    fn checked_let_with_literal_sum_annotation() {
+        let result =
+            check_str_one("let x: \"hello\" | false = \"hello\"", Some(&stdlib())).unwrap();
+        assert!(matches!(result, CheckedAst::Let { .. }));
+    }
 }

--- a/lentoc/lib/src/type_checker/tests.rs
+++ b/lentoc/lib/src/type_checker/tests.rs
@@ -167,6 +167,24 @@ mod tests {
     }
 
     #[test]
+    fn checked_list_type_decl() {
+        let result = check_str_one("type Foo = [int]", Some(&stdlib())).unwrap();
+        assert!(matches!(result, CheckedAst::TypeDecl { .. }));
+    }
+
+    #[test]
+    fn checked_list_type_annotation() {
+        let result = check_str_one("fn id(x: [int]) -> [int] = x", Some(&stdlib())).unwrap();
+        assert!(matches!(result, CheckedAst::FunctionDef { .. }));
+    }
+
+    #[test]
+    fn checked_list_type_in_function_sig() {
+        let result = check_str_one("fn f(x: [int]) -> [int] = x", Some(&stdlib())).unwrap();
+        assert!(matches!(result, CheckedAst::FunctionDef { .. }));
+    }
+
+    #[test]
     fn checked_function_def_has_all_params() {
         let result = check_str_one("fn add(x, y) = 1", Some(&stdlib())).unwrap();
         if let CheckedAst::FunctionDef { params, .. } = result {

--- a/lentoc/lib/src/type_checker/tests.rs
+++ b/lentoc/lib/src/type_checker/tests.rs
@@ -26,6 +26,22 @@ mod tests {
         }
     }
 
+    fn check_str_all(
+        input: &str,
+        init: Option<&Initializer>,
+    ) -> TypeCheckerResult<Vec<CheckedAst>> {
+        let mut parser = from_string(input.to_string());
+        let mut checker = TypeChecker::default();
+        if let Some(init) = init {
+            init.init_parser(&mut parser);
+            init.init_type_checker(&mut checker);
+        }
+        match parser.parse_all() {
+            Ok(ast) => checker.check_top_exprs(&ast),
+            Err(err) => Err(TypeErrorVariant::ParseError(err)),
+        }
+    }
+
     #[test]
     fn types() {
         let types = [
@@ -118,6 +134,36 @@ mod tests {
     fn checked_type_decl() {
         let result = check_str_one("type Foo = u8", Some(&stdlib())).unwrap();
         assert!(matches!(result, CheckedAst::TypeDecl { .. }));
+    }
+
+    #[test]
+    fn checked_record_type_decl() {
+        let result = check_str_one(
+            "type Eq = { eq: Self -> Self -> bool }",
+            Some(&stdlib()),
+        )
+        .unwrap();
+        assert!(matches!(result, CheckedAst::TypeDecl { .. }));
+    }
+
+    #[test]
+    fn checked_refinement_type_decl_and_use() {
+        let program = "type Nat = { v: int | v >= 0 }; fn id(x: Nat) -> Nat = x";
+        let checked = check_str_all(program, Some(&stdlib())).unwrap();
+        assert_eq!(checked.len(), 2);
+        assert!(matches!(checked[0], CheckedAst::TypeDecl { .. }));
+        assert!(matches!(checked[1], CheckedAst::FunctionDef { .. }));
+    }
+
+    #[test]
+    fn checked_generic_static_vec_alias_and_application() {
+        let program =
+            "type X = int; type MyArr T = [T; 6]; fn id(x: MyArr int) -> MyArr(X) = x";
+        let checked = check_str_all(program, Some(&stdlib())).unwrap();
+        assert_eq!(checked.len(), 3);
+        assert!(matches!(checked[0], CheckedAst::TypeDecl { .. }));
+        assert!(matches!(checked[1], CheckedAst::TypeDecl { .. }));
+        assert!(matches!(checked[2], CheckedAst::FunctionDef { .. }));
     }
 
     #[test]

--- a/lentoc/lib/src/type_checker/tests.rs
+++ b/lentoc/lib/src/type_checker/tests.rs
@@ -185,6 +185,25 @@ mod tests {
     }
 
     #[test]
+    fn checked_let_with_type_annotation() {
+        let result = check_str_one("let x: int = 5", Some(&stdlib())).unwrap();
+        assert!(matches!(result, CheckedAst::Let { .. }));
+    }
+
+    #[test]
+    fn checked_let_with_list_type_annotation() {
+        let result = check_str_one("let xs: [int] = [1, 2, 3]", Some(&stdlib())).unwrap();
+        assert!(matches!(result, CheckedAst::Let { .. }));
+    }
+
+    #[test]
+    fn checked_let_with_tuple_type_annotation() {
+        let result =
+            check_str_one("let pair: (int, bool) = (1, true)", Some(&stdlib())).unwrap();
+        assert!(matches!(result, CheckedAst::Let { .. }));
+    }
+
+    #[test]
     fn checked_function_def_has_all_params() {
         let result = check_str_one("fn add(x, y) = 1", Some(&stdlib())).unwrap();
         if let CheckedAst::FunctionDef { params, .. } = result {

--- a/lentoc/lib/src/type_checker/types.rs
+++ b/lentoc/lib/src/type_checker/types.rs
@@ -824,7 +824,10 @@ pub mod std_types {
     pub fn INT() -> Type {
         Type::Alias(
             Str::Str("int"),
-            Box::new(Type::Sum(vec![INT8, INT16, INT32, INT64, INT128, INTBIG])),
+            Box::new(Type::Sum(vec![
+                UINT(),
+                INT8, INT16, INT32, INT64, INT128, INTBIG,
+            ])),
         )
     }
 


### PR DESCRIPTION
This PR evolves the type-level AST and checking to support explicit, paper-aligned syntax forms.

## Changes

- **TypeAst refactor**: Replaced Binary/Constructor with Application, Lambda, Tuple, Sum, StaticVector, Refinement variants; added Array and List first-class variants
- **Renamed** Ast::StaticVec → Ast::Array, check_static_vec → check_array
- **Let binding type annotations**: Parser supports let x: T = expr; type checker verifies inferred type is a subtype of the declared annotation
- **Generic type aliases**: Support bare parameters (	ype MyArr T = ...) and parenthesized parameters (	ype MyArr(T) = ...); resolution uses specialize with parameter substitution
- **Refinement types**: Syntax { binder: base | predicate }; predicate stored as Box<Ast>; type checker validates the base type
- **Array syntax**: [elem; len] lowered to fixed-length Type::Tuple; length must be a non-negative integer literal
- **List type syntax**: [T] as a first-class TypeAst::List variant
- **Record types**: Parser support for { field: T, ... } type syntax
- **Primitive operators**: Comparison operators (>, >=, <, <=, !=) added as parser intrinsics for refinement predicates
- **INT() expanded**: int type now includes unsigned integer types, so u8 <: int via sum type subtyping

## Testing

- Parser and type checker tests for all new syntax forms
- Annotation mismatch rejection test
- Supertype annotation test (let x: int = 2)