### PR TITLE
Fix parser lookahead and preserve array/member-access structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Cargo.lock
 .idea/
 *.md
 !README.md
+!CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,10 @@ The Lento compiler is an open-source project, and contributions are highly appre
 Here are some ways you can contribute to the development of the Lento compiler:
 
 - [Contributing to the Lento compiler](#contributing-to-the-lento-compiler)
-  - [Reporting issues](#reporting-issues)
-  - [Contributing documentation](#contributing-documentation)
-  - [Contributing code](#contributing-code)
-  - [Contributing to the backends](#contributing-to-the-backends)
+	- [Reporting issues](#reporting-issues)
+	- [Contributing documentation](#contributing-documentation)
+	- [Contributing code](#contributing-code)
+	- [Contributing to the backends](#contributing-to-the-backends)
 
 ## Reporting issues
 
@@ -34,10 +34,10 @@ The Lento compiler is written in the Rust programming language. If you are inter
    1. If you are adding new functionality, please add tests to cover the new code.
    2. Run the tests with `cargo test`.
 6. Commit your changes and push them to your fork on GitHub.
-7. Create a pull request from your branch to the `develop` branch of the Lento repository.
+7. Create a pull request from your branch to the `main` branch of the Lento repository.
 8. Wait for the maintainers to review your pull request and provide feedback.
    1. Address any feedback and make any necessary changes to your pull request.
-9. If your pull request is approved, it will be merged into the `develop` branch and will be included in the next release of Lento! 🎉
+9. If your pull request is approved, it will be merged into the `main` branch and will be included in the next release of Lento! 🎉
 
 ## Contributing to the backends
 

--- a/examples/basic/types.lt
+++ b/examples/basic/types.lt
@@ -34,7 +34,7 @@ type Age = { v: int | 0 <= v <= 200 }
 
 type Day = { v: int | 1 <= v <= 31 }
 type Month = { v: int | 1 <= v <= 12 }
-type YearR = { v: int | 0 <= v <= 9999 }
+type Year = { v: int | 0 <= v <= 9999 }
 type Date = { day: Day, month: Month, year: Year }
 
 // Value-parameterized refinements (dependent refinement aliases)

--- a/lentoc/lib/src/interpreter/eval.rs
+++ b/lentoc/lib/src/interpreter/eval.rs
@@ -241,6 +241,10 @@ fn eval_assignment(
         BindPattern::Variable { name, .. } => {
             env.add_value(Str::String(name.clone()), value.clone(), pattern.info())?
         }
+        BindPattern::MemberAccess { .. } => {
+            let name = pattern.binding_name().expect("member access binding name");
+            env.add_value(Str::String(name), value.clone(), pattern.info())?
+        }
         BindPattern::Tuple { elements, .. } => {
             let Value::Tuple(values, _) = value else {
                 unreachable!("This should have been checked by the type checker");

--- a/lentoc/lib/src/lexer/lexer.rs
+++ b/lentoc/lib/src/lexer/lexer.rs
@@ -395,24 +395,21 @@ impl<R: Read> Lexer<R> {
     }
 
     /// Peek the next token from the source code, ignoring tokens that match the predicate.
-    /// Consumes matching tokens from the front of the buffer and skips `skip` non-matching tokens.
+    /// Skips `skip` non-matching tokens (lookahead) without consuming anything.
     pub fn peek_token_not(&mut self, predicate: impl Fn(&Token) -> bool, skip: usize) -> LexResult {
+        let mut idx = 0usize;
         let mut skipped = 0usize;
         loop {
-            let token = self.peek_token(0);
-            if let Err(_err) = &token {
-                return token;
-            }
-            let t = token.as_ref().unwrap();
-            if predicate(&t.token) {
-                self.next_token().unwrap();
+            let token = self.peek_token(idx);
+            if check_token(&token, &predicate) {
+                idx += 1;
                 continue;
             }
             if skipped == skip {
                 return token;
             }
-            self.next_token().unwrap();
             skipped += 1;
+            idx += 1;
         }
     }
 

--- a/lentoc/lib/src/lexer/lexer.rs
+++ b/lentoc/lib/src/lexer/lexer.rs
@@ -395,33 +395,25 @@ impl<R: Read> Lexer<R> {
     }
 
     /// Peek the next token from the source code, ignoring tokens that match the predicate.
-    /// Or return the next peeked token.
+    /// Consumes matching tokens from the front of the buffer and skips `skip` non-matching tokens.
     pub fn peek_token_not(&mut self, predicate: impl Fn(&Token) -> bool, skip: usize) -> LexResult {
-        let mut idx = 0usize;
-        let mut token = self.peek_token(idx);
-        for i in 0..skip {
-            // Find the next non-matching token
-            while check_token(&token, &predicate) {
-                idx += 1;
-                token = self.peek_token(idx);
-
-                // Optimize for EOF
-                if let Err(err) = &token {
-                    if err.is_eof_error() {
-                        return token; // Search no further!
-                    }
-                }
+        let mut skipped = 0usize;
+        loop {
+            let token = self.peek_token(0);
+            if let Err(_err) = &token {
+                return token;
             }
-            // We found a non-matching token!
-            if i < skip - 1 {
-                log::trace!("Skipping token ({}/{}): {:?}", i + 1, skip, token);
-                idx += 1;
-                token = self.peek_token(idx);
-            } else {
-                log::trace!("Found token ({}/{}): {:?}", i + 1, skip, token);
+            let t = token.as_ref().unwrap();
+            if predicate(&t.token) {
+                self.next_token().unwrap();
+                continue;
             }
+            if skipped == skip {
+                return token;
+            }
+            self.next_token().unwrap();
+            skipped += 1;
         }
-        token
     }
 
     /// Get the next token from the source code, ignoring tokens that match the predicate.

--- a/lentoc/lib/src/lexer/tests.rs
+++ b/lentoc/lib/src/lexer/tests.rs
@@ -346,4 +346,16 @@ mod tests {
         let token = Token::EndOfFile;
         assert_eq!(lexer.next_token().unwrap().token, token);
     }
+
+    #[test]
+    fn peek_token_not_is_non_consuming_with_skip() {
+        let mut lexer = from_str("a\n b\n c");
+        init(&mut lexer);
+
+        let token = lexer.peek_token_not(|t| matches!(t, Token::Newline), 1).unwrap();
+        assert_eq!(token.token, Token::Identifier("b".to_string()));
+
+        let token = lexer.next_token().unwrap();
+        assert_eq!(token.token, Token::Identifier("a".to_string()));
+    }
 }

--- a/lentoc/lib/src/lexer/token.rs
+++ b/lentoc/lib/src/lexer/token.rs
@@ -170,24 +170,16 @@ impl Token {
         matches!(self, Token::Keyword(_))
     }
 
-    pub fn is_opening_keyword(&self) -> bool {
+    pub fn is_statement_start(&self) -> bool {
         matches!(
             self,
             Token::Keyword(Keyword::Fn)
                 | Token::Keyword(Keyword::Let)
                 | Token::Keyword(Keyword::Type)
                 | Token::Keyword(Keyword::Use)
-                | Token::Keyword(Keyword::Effect)
                 | Token::Keyword(Keyword::Handle)
                 | Token::Keyword(Keyword::With)
                 | Token::Keyword(Keyword::Infix)
-                | Token::Keyword(Keyword::Ensures)
-                | Token::Keyword(Keyword::Requires)
-                | Token::Keyword(Keyword::Match)
-                | Token::Keyword(Keyword::If)
-                | Token::Keyword(Keyword::Else)
-                | Token::Keyword(Keyword::For)
-                | Token::Keyword(Keyword::While)
         )
     }
 

--- a/lentoc/lib/src/lexer/token.rs
+++ b/lentoc/lib/src/lexer/token.rs
@@ -166,7 +166,32 @@ impl Token {
         matches!(self, Token::Identifier(_))
     }
 
-    pub fn is_keyword(&self, kw: &Keyword) -> bool {
+    pub fn is_keyword(&self) -> bool {
+        matches!(self, Token::Keyword(_))
+    }
+
+    pub fn is_opening_keyword(&self) -> bool {
+        matches!(
+            self,
+            Token::Keyword(Keyword::Fn)
+                | Token::Keyword(Keyword::Let)
+                | Token::Keyword(Keyword::Type)
+                | Token::Keyword(Keyword::Use)
+                | Token::Keyword(Keyword::Effect)
+                | Token::Keyword(Keyword::Handle)
+                | Token::Keyword(Keyword::With)
+                | Token::Keyword(Keyword::Infix)
+                | Token::Keyword(Keyword::Ensures)
+                | Token::Keyword(Keyword::Requires)
+                | Token::Keyword(Keyword::Match)
+                | Token::Keyword(Keyword::If)
+                | Token::Keyword(Keyword::Else)
+                | Token::Keyword(Keyword::For)
+                | Token::Keyword(Keyword::While)
+        )
+    }
+
+    pub fn eq_keyword(&self, kw: &Keyword) -> bool {
         matches!(self, Token::Keyword(k) if k == kw)
     }
 

--- a/lentoc/lib/src/parser/parser.rs
+++ b/lentoc/lib/src/parser/parser.rs
@@ -149,6 +149,14 @@ pub fn intrinsic_operators() -> Vec<OpInfo> {
             associativity: OpAssoc::Left,
             allow_trailing: false,
         },
+        // Logical AND (used in refinement predicates)
+        OpInfo {
+            symbol: "&&".to_string(),
+            position: OpPos::Infix,
+            precedence: prec::LOGICAL_AND_PREC,
+            associativity: OpAssoc::Left,
+            allow_trailing: false,
+        },
         // Comparison operators (needed for refinement predicates)
         OpInfo {
             symbol: ">".to_string(),
@@ -771,8 +779,9 @@ impl<R: Read> Parser<R> {
         let mut expr = self.parse_term()?;
         // println!("Parsed term: {:?}", expr);
         while let Ok(nt) = self.lexer.peek_token(0) {
+            // Stop on statement-starting keywords so they are not consumed as part of the current expression
             let is_top_level_nl_term = min_prec == 0 && nt.token.is_top_level_terminal(true);
-            if nt.token.is_terminator() || is_top_level_nl_term {
+            if nt.token.is_terminator() || is_top_level_nl_term || nt.token.is_opening_keyword() {
                 break; // Stop parsing on expression terminators
             }
             if let Token::Operator(op) = &nt.token {
@@ -824,7 +833,17 @@ impl<R: Read> Parser<R> {
                     break;
                 }
             }
+            // Before attempting function application, check if the next non-ignored token
+            // is a statement-starting keyword. If so, stop parsing.
+            if let Ok(next_real) = self.lexer.peek_token_not(pred::ignore, 0) {
+                if next_real.token.is_opening_keyword() {
+                    break;
+                }
+            }
             if FUNCTION_APP_PREC > min_prec {
+                if pred::ignore(&nt.token) {
+                    break;
+                }
                 let call_info = expr.info().join(&nt.info);
                 // Allow all definitions in the parser, even if they are not valid in the current context
                 // expr = utils::call(expr, self.parse_term()?, call_info)?;
@@ -859,15 +878,18 @@ impl<R: Read> Parser<R> {
         let Ok(t) = self.lexer.peek_token_not(pred::ignore, 0) else {
             return Ok(None);
         };
-        if t.token.is_keyword(&Keyword::Let) {
+        if !t.token.is_opening_keyword() {
+            return Ok(None);
+        }
+        if t.token.eq_keyword(&Keyword::Let) {
             self.lexer.next_token().unwrap(); // consume let
             return self.parse_let_stmt().map(Some);
         }
-        if t.token.is_keyword(&Keyword::Fn) {
+        if t.token.eq_keyword(&Keyword::Fn) {
             self.lexer.next_token().unwrap(); // consume fn
             return self.parse_fn().map(Some);
         }
-        if t.token.is_keyword(&Keyword::Type) {
+        if t.token.eq_keyword(&Keyword::Type) {
             self.lexer.next_token().unwrap(); // consume type
             return self.parse_type_decl().map(Some);
         }
@@ -876,7 +898,9 @@ impl<R: Read> Parser<R> {
 
     /// Parse a `let` statement after the `let` keyword has been consumed.
     fn parse_let_stmt(&mut self) -> ParseResult {
-        let target_expr = self.parse_term()?;
+        // Use parse_expr with a precedence that stops before `=` (ASSIGNMENT_PREC)
+        // but still parses member access (`(Eq int).eq`) and other infix operators
+        let target_expr = self.parse_expr(prec::ASSIGNMENT_PREC + 1)?;
         let mut annotation = None;
 
         // Check for optional type annotation `: type`
@@ -884,8 +908,7 @@ impl<R: Read> Parser<R> {
             if matches!(next.token, Token::Colon) {
                 self.lexer.next_token().unwrap(); // consume ':'
                 let ann_expr = self.parse_expr(prec::COMMA_PREC + 1)?;
-                annotation =
-                    Some(crate::type_checker::specialize::into_type_ast(ann_expr)?);
+                annotation = Some(crate::type_checker::specialize::into_type_ast(ann_expr)?);
             }
         }
 
@@ -968,30 +991,29 @@ impl<R: Read> Parser<R> {
     /// fn name(param1, param2, ...) -> return_type ! { effects } { body }
     /// ```
     fn parse_fn(&mut self) -> ParseResult {
-        // Parse function name
-        let name_t = self
-            .lexer
-            .expect_next_token_not(pred::ignore)
-            .map_err(|err| {
-                ParseError::new(
-                    "Expected function name after fn".to_string(),
-                    err.info().clone(),
-                )
-            })?;
-        let name = match &name_t.token {
-            Token::Identifier(id) => id.clone(),
-            _ => {
-                return Err(ParseError::new(
-                    format!(
-                        "Expected function name, but found {}",
-                        name_t.token.to_string().light_red()
-                    ),
-                    name_t.info.clone(),
-                )
-                .with_label("This should be a function name".to_string(), name_t.info));
+        // Parse function name (supports qualified names like `(Eq List T).eq`)
+        let (name, name_info) = self.parse_fn_name()?;
+
+        // Optional generic type parameters: `<a, b: Eq>`
+        if let Ok(next) = self.lexer.peek_token_not(pred::ignore, 0) {
+            if matches!(&next.token, Token::Operator(s) if s == "<") {
+                self.lexer.next_token().unwrap(); // consume <
+                let mut depth = 1usize;
+                while depth > 0 {
+                    let t = self.lexer.next_token().map_err(|_| {
+                        ParseError::new(
+                            "Expected `>` after generic parameters".to_string(),
+                            LineInfo::default(),
+                        )
+                    })?;
+                    match &t.token {
+                        Token::Operator(s) if s == "<" => depth += 1,
+                        Token::Operator(s) if s == ">" => depth -= 1,
+                        _ => {}
+                    }
+                }
             }
-        };
-        let name_info = name_t.info;
+        }
 
         // Peek to distinguish declaration (::) from definition ((...))
         let next = self.lexer.peek_token_not(pred::ignore, 0).map_err(|err| {
@@ -1034,6 +1056,80 @@ impl<R: Read> Parser<R> {
             signature,
             info: name_info.join(&sig_info),
         })
+    }
+
+    fn parse_fn_name(&mut self) -> Result<(String, LineInfo), ParseError> {
+        let name_t = self.lexer.peek_token_not(pred::ignore, 0).map_err(|err| {
+            ParseError::new(
+                "Expected function name after fn".to_string(),
+                err.info().clone(),
+            )
+        })?;
+        if matches!(&name_t.token, Token::LeftParen { .. }) {
+            // Qualified name: `(Type App).field` or `(Type App)`
+            self.lexer.next_token().unwrap(); // consume (
+            let inner = self.parse_expr(prec::COMMA_PREC)?;
+            self.parse_expected_eq(Token::RightParen, ")")?;
+            let mut name_expr: Ast = inner;
+            // Parse optional `.field`
+            if let Ok(nt) = self.lexer.peek_token_not(pred::ignore, 0) {
+                if matches!(&nt.token, Token::Operator(s) if s == MEMBER_ACCESS_SYM) {
+                    self.lexer.next_token().unwrap(); // consume .
+                    let field_t = self
+                        .lexer
+                        .expect_next_token_not(pred::ignore)
+                        .map_err(|_| {
+                            ParseError::new(
+                                "Expected field name after `.`".to_string(),
+                                nt.info.clone(),
+                            )
+                        })?;
+                    let field_key = match &field_t.token {
+                        Token::Identifier(id) => RecordKey::String(id.clone()),
+                        _ => {
+                            return Err(ParseError::new(
+                                format!(
+                                    "Expected field name, found {}",
+                                    field_t.token.to_string().light_red()
+                                ),
+                                field_t.info.clone(),
+                            ));
+                        }
+                    };
+                    let name_info = name_expr.info().clone();
+                    name_expr = Ast::MemberAccess {
+                        expr: Box::new(name_expr),
+                        field: field_key,
+                        info: name_info.join(&field_t.info),
+                    };
+                }
+            }
+            Ok((name_expr.print_expr(), name_expr.info().clone()))
+        } else {
+            let t = self
+                .lexer
+                .expect_next_token_not(pred::ignore)
+                .map_err(|err| {
+                    ParseError::new(
+                        "Expected function name after fn".to_string(),
+                        err.info().clone(),
+                    )
+                })?;
+            let name = match &t.token {
+                Token::Identifier(id) => id.clone(),
+                _ => {
+                    return Err(ParseError::new(
+                        format!(
+                            "Expected function name, but found {}",
+                            t.token.to_string().light_red()
+                        ),
+                        t.info.clone(),
+                    )
+                    .with_label("This should be a function name".to_string(), t.info));
+                }
+            };
+            Ok((name, t.info))
+        }
     }
 
     fn parse_fn_definition(&mut self, name: String, name_info: LineInfo) -> ParseResult {
@@ -1116,14 +1212,14 @@ impl<R: Read> Parser<R> {
         let mut ensures: Option<Ast> = None;
         loop {
             if let Ok(t) = self.lexer.peek_token_not(pred::ignore, 0) {
-                if t.token.is_keyword(&Keyword::Requires) {
+                if t.token.eq_keyword(&Keyword::Requires) {
                     self.lexer.next_token().unwrap();
                     self.parse_expected_eq(Token::LeftBrace, "{")?;
                     requires = Some(self.parse_top()?);
                     self.parse_expected_eq(Token::RightBrace, "}")?;
                     continue;
                 }
-                if t.token.is_keyword(&Keyword::Ensures) {
+                if t.token.eq_keyword(&Keyword::Ensures) {
                     self.lexer.next_token().unwrap();
                     self.parse_expected_eq(Token::LeftBrace, "{")?;
                     ensures = Some(self.parse_top()?);
@@ -1199,7 +1295,7 @@ impl<R: Read> Parser<R> {
         let name_info = name_token.info;
 
         // Optional type parameters:
-        // - parenthesized: `type Name(T, U) = ...`
+        // - parenthesized: `type Name(T, U) = ...` or `type Name(T: Type, U: Type) = ...`
         // - bare: `type Name T U = ...`
         let params: Vec<Ast> = if let Ok(t) = self.lexer.peek_token_not(pred::ignore, 0) {
             if matches!(t.token, Token::LeftParen { .. }) {
@@ -1221,6 +1317,13 @@ impl<R: Read> Parser<R> {
                                 format!("Expected parameter name, found {}", param_name.token),
                                 param_name.info.clone(),
                             ))
+                        }
+                    }
+                    // Optional type annotation `: TypeExpr`
+                    if let Ok(next) = self.lexer.peek_token_not(pred::ignore, 0) {
+                        if matches!(next.token, Token::Colon) {
+                            self.lexer.next_token().unwrap(); // consume :
+                            self.parse_expr(prec::COMMA_PREC + 1)?; // parse and discard type annotation
                         }
                     }
                     if let Ok(t) = self.lexer.peek_token_not(pred::ignore, 0) {
@@ -1263,6 +1366,26 @@ impl<R: Read> Parser<R> {
         } else {
             vec![]
         };
+
+        // Optional constraints after `)`: `: Constraint1, Constraint2`
+        if let Ok(t) = self.lexer.peek_token_not(pred::ignore, 0) {
+            if matches!(t.token, Token::Colon) {
+                self.lexer.next_token().unwrap(); // consume :
+                                                  // Parse constraint identifiers separated by commas until `=`
+                loop {
+                    self.parse_primary()?;
+                    if let Ok(next) = self.lexer.peek_token_not(pred::ignore, 0) {
+                        if matches!(&next.token, Token::Operator(s) if s == ",") {
+                            self.lexer.next_token().unwrap(); // consume ,
+                            continue;
+                        }
+                        break;
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
 
         // Expect `=`
         if let Ok(t) = self.lexer.peek_token_not(pred::ignore, 0) {

--- a/lentoc/lib/src/parser/parser.rs
+++ b/lentoc/lib/src/parser/parser.rs
@@ -781,7 +781,7 @@ impl<R: Read> Parser<R> {
         while let Ok(nt) = self.lexer.peek_token(0) {
             // Stop on statement-starting keywords so they are not consumed as part of the current expression
             let is_top_level_nl_term = min_prec == 0 && nt.token.is_top_level_terminal(true);
-            if nt.token.is_terminator() || is_top_level_nl_term || nt.token.is_opening_keyword() {
+            if nt.token.is_terminator() || is_top_level_nl_term || nt.token.is_statement_start() {
                 break; // Stop parsing on expression terminators
             }
             if let Token::Operator(op) = &nt.token {
@@ -836,7 +836,7 @@ impl<R: Read> Parser<R> {
             // Before attempting function application, check if the next non-ignored token
             // is a statement-starting keyword. If so, stop parsing.
             if let Ok(next_real) = self.lexer.peek_token_not(pred::ignore, 0) {
-                if next_real.token.is_opening_keyword() {
+                if next_real.token.is_statement_start() {
                     break;
                 }
             }
@@ -878,7 +878,7 @@ impl<R: Read> Parser<R> {
         let Ok(t) = self.lexer.peek_token_not(pred::ignore, 0) else {
             return Ok(None);
         };
-        if !t.token.is_opening_keyword() {
+        if !t.token.is_statement_start() {
             return Ok(None);
         }
         if t.token.eq_keyword(&Keyword::Let) {

--- a/lentoc/lib/src/parser/parser.rs
+++ b/lentoc/lib/src/parser/parser.rs
@@ -841,7 +841,7 @@ impl<R: Read> Parser<R> {
                 }
             }
             if FUNCTION_APP_PREC > min_prec {
-                if pred::ignore(&nt.token) {
+                if pred::ignore(&nt.token) || matches!(nt.token, Token::Colon) {
                     break;
                 }
                 let call_info = expr.info().join(&nt.info);

--- a/lentoc/lib/src/parser/parser.rs
+++ b/lentoc/lib/src/parser/parser.rs
@@ -882,15 +882,15 @@ impl<R: Read> Parser<R> {
             return Ok(None);
         }
         if t.token.eq_keyword(&Keyword::Let) {
-            self.lexer.next_token().unwrap(); // consume let
+            self.lexer.expect_next_token_not(pred::ignore).unwrap(); // consume let
             return self.parse_let_stmt().map(Some);
         }
         if t.token.eq_keyword(&Keyword::Fn) {
-            self.lexer.next_token().unwrap(); // consume fn
+            self.lexer.expect_next_token_not(pred::ignore).unwrap(); // consume fn
             return self.parse_fn().map(Some);
         }
         if t.token.eq_keyword(&Keyword::Type) {
-            self.lexer.next_token().unwrap(); // consume type
+            self.lexer.expect_next_token_not(pred::ignore).unwrap(); // consume type
             return self.parse_type_decl().map(Some);
         }
         Ok(None)

--- a/lentoc/lib/src/parser/pattern.rs
+++ b/lentoc/lib/src/parser/pattern.rs
@@ -14,7 +14,7 @@ use std::hash::Hash;
 /// - Function definitions
 /// - Function arguments
 /// - Destructuring assignments
-#[derive(Debug, Clone, Eq)]
+#[derive(Debug, Clone)]
 pub enum BindPattern {
     /// A variable binding pattern.
     Variable {
@@ -33,6 +33,12 @@ pub enum BindPattern {
     Record {
         /// The fields of the record.
         fields: Vec<(RecordKey, BindPattern)>,
+        info: LineInfo,
+    },
+    /// A qualified binding target like `(Eq int).eq`.
+    MemberAccess {
+        expr: Box<Ast>,
+        field: RecordKey,
         info: LineInfo,
     },
     /// A list binding pattern.
@@ -64,6 +70,7 @@ impl BindPattern {
             BindPattern::Variable { info, .. } => info,
             BindPattern::Tuple { info, .. } => info,
             BindPattern::Record { info, .. } => info,
+            BindPattern::MemberAccess { info, .. } => info,
             BindPattern::List { info, .. } => info,
             BindPattern::Wildcard => panic!("Wildcard pattern has no line info"),
             BindPattern::Literal { info, .. } => info,
@@ -90,6 +97,11 @@ impl BindPattern {
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(BindPattern::Record { fields, info })
             }
+            Ast::MemberAccess { expr, field, info } => Ok(BindPattern::MemberAccess {
+                expr,
+                field,
+                info,
+            }),
             Ast::List { exprs, info } => {
                 let elements = exprs
                     .into_iter()
@@ -104,11 +116,6 @@ impl BindPattern {
                 )?,
                 info,
             }),
-            Ast::MemberAccess { expr, field, info } => {
-                let base = expr.print_expr();
-                let name = format!("{}.{}", base, field.to_string());
-                Ok(BindPattern::Variable { name, info })
-            }
             _ => Err(ParseError::new(
                 format!("Invalid binding pattern: {}", expr.print_expr()),
                 expr.info().clone(),
@@ -129,6 +136,7 @@ impl BindPattern {
                     element.specialize(_judgements, _changed);
                 }
             }
+            BindPattern::MemberAccess { .. } => (),
             BindPattern::List { elements, .. } => {
                 for element in elements {
                     element.specialize(_judgements, _changed);
@@ -160,6 +168,7 @@ impl BindPattern {
                     .collect::<Vec<String>>()
                     .join(", ")
             ),
+            BindPattern::MemberAccess { expr, field, .. } => format!("{}.{}", expr.print_expr(), field),
             BindPattern::List { elements, .. } => format!(
                 "[{}]",
                 elements
@@ -199,6 +208,9 @@ impl BindPattern {
                 result.push_str(" }");
                 result
             }
+            BindPattern::MemberAccess { expr, field, .. } => {
+                format!("{}.{}", expr.print_expr(), field)
+            }
             BindPattern::List { elements, .. } => {
                 let mut result = "[".to_string();
                 for (i, v) in elements.iter().enumerate() {
@@ -219,6 +231,16 @@ impl BindPattern {
     pub fn is_wildcard(&self) -> bool {
         matches!(self, BindPattern::Wildcard)
     }
+
+    pub fn binding_name(&self) -> Option<String> {
+        match self {
+            BindPattern::Variable { name, .. } => Some(name.clone()),
+            BindPattern::MemberAccess { expr, field, .. } => {
+                Some(format!("{}.{}", expr.print_expr(), field))
+            }
+            _ => None,
+        }
+    }
 }
 
 impl PartialEq for BindPattern {
@@ -227,6 +249,10 @@ impl PartialEq for BindPattern {
             (Self::Variable { name: l0, .. }, Self::Variable { name: r0, .. }) => l0 == r0,
             (Self::Tuple { elements: l0, .. }, Self::Tuple { elements: r0, .. }) => l0 == r0,
             (Self::Record { fields: l0, .. }, Self::Record { fields: r0, .. }) => l0 == r0,
+            (
+                Self::MemberAccess { expr: l0, field: l1, .. },
+                Self::MemberAccess { expr: r0, field: r1, .. },
+            ) => l0 == r0 && l1 == r1,
             (Self::List { elements: l0, .. }, Self::List { elements: r0, .. }) => l0 == r0,
             (Self::Wildcard, Self::Wildcard) => true,
             (Self::Literal { value: l0, .. }, Self::Literal { value: r0, .. }) => l0 == r0,
@@ -235,6 +261,8 @@ impl PartialEq for BindPattern {
         }
     }
 }
+
+impl Eq for BindPattern {}
 
 impl Hash for BindPattern {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -250,6 +278,10 @@ impl Hash for BindPattern {
                     key.hash(state);
                     value.hash(state);
                 }
+            }
+            BindPattern::MemberAccess { expr, field, .. } => {
+                expr.print_expr().hash(state);
+                field.hash(state);
             }
             BindPattern::List { elements, .. } => {
                 for element in elements {

--- a/lentoc/lib/src/parser/pattern.rs
+++ b/lentoc/lib/src/parser/pattern.rs
@@ -104,6 +104,11 @@ impl BindPattern {
                 )?,
                 info,
             }),
+            Ast::MemberAccess { expr, field, info } => {
+                let base = expr.print_expr();
+                let name = format!("{}.{}", base, field.to_string());
+                Ok(BindPattern::Variable { name, info })
+            }
             _ => Err(ParseError::new(
                 format!("Invalid binding pattern: {}", expr.print_expr()),
                 expr.info().clone(),

--- a/lentoc/lib/src/parser/tests.rs
+++ b/lentoc/lib/src/parser/tests.rs
@@ -656,7 +656,7 @@ mod tests {
                 assert_eq!(name, "f");
             }
             assert!(matches!(*expr, Ast::Lambda { .. }));
-            if let Ast::Lambda { param, body, .. } = *expr {
+            if let Ast::Lambda {  body, .. } = *expr {
                 // assert!(param.ty.is_some());
                 // if let Some(TypeAst::Identifier { name, .. }) = param.ty {
                 //     assert_eq!(name, "int");
@@ -694,7 +694,7 @@ mod tests {
                 assert_eq!(name, "f");
             }
             assert!(matches!(*expr, Ast::Lambda { .. }));
-            if let Ast::Lambda { param, body, .. } = *expr {
+            if let Ast::Lambda {  body, .. } = *expr {
                 // assert!(param.ty.is_some());
                 // if let Some(TypeAst::Identifier { name, .. }) = param.ty {
                 //     assert_eq!(name, "int");
@@ -736,7 +736,7 @@ mod tests {
                 assert_eq!(name, "f");
             }
             assert!(matches!(*expr, Ast::Lambda { .. }));
-            if let Ast::Lambda { param, body, .. } = *expr {
+            if let Ast::Lambda {  body, .. } = *expr {
                 // assert!(param.ty.is_none());
                 // if let BindPattern::Variable { name, .. } = &param.pattern {
                 //     assert_eq!(name, "x");
@@ -771,7 +771,7 @@ mod tests {
                 assert_eq!(name, "f");
             }
             assert!(matches!(*expr, Ast::Lambda { .. }));
-            if let Ast::Lambda { param, body, .. } = *expr {
+            if let Ast::Lambda {  body, .. } = *expr {
                 // assert!(param.ty.is_none());
                 // if let BindPattern::Variable { name, .. } = &param.pattern {
                 //     assert_eq!(name, "x");
@@ -810,7 +810,7 @@ mod tests {
             //     assert_eq!(name, "int");
             // }
             assert!(matches!(*expr, Ast::Lambda { .. }));
-            if let Ast::Lambda { param, body, .. } = *expr {
+            if let Ast::Lambda {  body, .. } = *expr {
                 // assert!(param.ty.is_some());
                 // if let Some(TypeAst::Identifier { name, .. }) = param.ty {
                 //     assert_eq!(name, "int");
@@ -848,7 +848,7 @@ mod tests {
                 assert_eq!(name, "f");
             }
             assert!(matches!(*expr, Ast::Lambda { .. }));
-            if let Ast::Lambda { param, body, .. } = *expr {
+            if let Ast::Lambda {  body, .. } = *expr {
                 // assert!(param.ty.is_none());
                 // if let BindPattern::Variable { name, .. } = &param.pattern {
                 //     assert_eq!(name, "x");
@@ -883,7 +883,7 @@ mod tests {
                 assert_eq!(name, "f");
             }
             assert!(matches!(*expr, Ast::Lambda { .. }));
-            if let Ast::Lambda { param, body, .. } = *expr {
+            if let Ast::Lambda {  body, .. } = *expr {
                 // assert!(param.ty.is_some());
                 // if let Some(TypeAst::Identifier { name, .. }) = param.ty {
                 //     assert_eq!(name, "int");
@@ -892,7 +892,7 @@ mod tests {
                 //     assert_eq!(name, "x");
                 // }
                 assert!(matches!(*body, Ast::Lambda { .. }));
-                if let Ast::Lambda { param, body, .. } = *body {
+                if let Ast::Lambda {  body, .. } = *body {
                     // assert!(param.ty.is_some());
                     // if let Some(TypeAst::Identifier { name, .. }) = param.ty {
                     //     assert_eq!(name, "int");
@@ -937,7 +937,7 @@ mod tests {
                 assert_eq!(name, "f");
             }
             assert!(matches!(*expr, Ast::Lambda { .. }));
-            if let Ast::Lambda { param, body, .. } = *expr {
+            if let Ast::Lambda {  body, .. } = *expr {
                 // assert!(param.ty.is_some());
                 // if let Some(TypeAst::Identifier { name, .. }) = param.ty {
                 //     assert_eq!(name, "int");
@@ -946,7 +946,7 @@ mod tests {
                 //     assert_eq!(name, "x");
                 // }
                 assert!(matches!(*body, Ast::Lambda { .. }));
-                if let Ast::Lambda { param, body, .. } = *body {
+                if let Ast::Lambda {  body, .. } = *body {
                     // assert!(param.ty.is_some());
                     // if let Some(TypeAst::Identifier { name, .. }) = param.ty {
                     //     assert_eq!(name, "int");
@@ -995,7 +995,7 @@ mod tests {
             //     assert_eq!(name, "int");
             // }
             assert!(matches!(*expr, Ast::Lambda { .. }));
-            if let Ast::Lambda { param, body, .. } = *expr {
+            if let Ast::Lambda {  body, .. } = *expr {
                 // assert!(param.ty.is_some());
                 // if let Some(TypeAst::Identifier { name, .. }) = param.ty {
                 //     assert_eq!(name, "int");
@@ -1004,7 +1004,7 @@ mod tests {
                 //     assert_eq!(name, "x");
                 // }
                 assert!(matches!(*body, Ast::Lambda { .. }));
-                if let Ast::Lambda { param, body, .. } = *body {
+                if let Ast::Lambda {  body, .. } = *body {
                     // assert!(param.ty.is_some());
                     // if let Some(TypeAst::Identifier { name, .. }) = param.ty {
                     //     assert_eq!(name, "int");
@@ -1048,7 +1048,7 @@ mod tests {
                 assert_eq!(name, "f");
             }
             assert!(matches!(*expr, Ast::Lambda { .. }));
-            if let Ast::Lambda { param, body, .. } = *expr {
+            if let Ast::Lambda {  body, .. } = *expr {
                 // assert!(param.ty.is_some());
                 // if let Some(TypeAst::Identifier { name, .. }) = param.ty {
                 //     assert_eq!(name, "int");
@@ -1057,7 +1057,7 @@ mod tests {
                 //     assert_eq!(name, "x");
                 // }
                 assert!(matches!(*body, Ast::Lambda { .. }));
-                if let Ast::Lambda { param, body, .. } = *body {
+                if let Ast::Lambda {  body, .. } = *body {
                     // assert!(param.ty.is_some());
                     // if let Some(TypeAst::Identifier { name, .. }) = param.ty {
                     //     assert_eq!(name, "int");
@@ -1104,7 +1104,7 @@ mod tests {
                 assert_eq!(name, "f");
             }
             assert!(matches!(*expr, Ast::Lambda { .. }));
-            if let Ast::Lambda { param, body, .. } = *expr {
+            if let Ast::Lambda {  body, .. } = *expr {
                 // assert!(param.ty.is_some());
                 // if let Some(TypeAst::Identifier { name, .. }) = param.ty {
                 //     assert_eq!(name, "int");
@@ -1113,7 +1113,7 @@ mod tests {
                 //     assert_eq!(name, "x");
                 // }
                 assert!(matches!(*body, Ast::Lambda { .. }));
-                if let Ast::Lambda { param, body, .. } = *body {
+                if let Ast::Lambda {  body, .. } = *body {
                     // assert!(param.ty.is_some());
                     // if let Some(TypeAst::Identifier { name, .. }) = param.ty {
                     //     assert_eq!(name, "int");

--- a/lentoc/lib/src/parser/tests.rs
+++ b/lentoc/lib/src/parser/tests.rs
@@ -7,7 +7,7 @@ mod tests {
         },
         parser::{ast::Ast, parser::from_string, pattern::BindPattern},
         stdlib::init::{stdlib, Initializer},
-        type_checker::checked_ast::TypeAst,
+        type_checker::checked_ast::{ArrayLenAst, TypeAst},
         util::error::LineInfo,
     };
 
@@ -1268,10 +1268,49 @@ mod tests {
             assert_eq!(params.len(), 1);
             assert!(matches!(body, TypeAst::Array { .. }));
             if let TypeAst::Array { len, .. } = body {
-                assert_eq!(len, 6);
+                assert_eq!(len, ArrayLenAst::Known(6));
             }
         } else {
             panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
+    fn type_decl_static_vec_symbolic_len() {
+        let result = parse_str_one("type MyArr(n: int, T: Type) = [T; n]", Some(&stdlib())).unwrap();
+        if let Ast::TypeDecl { body, .. } = result {
+            if let TypeAst::Array { len, .. } = body {
+                assert_eq!(len, ArrayLenAst::Symbol("n".to_string()));
+            } else {
+                panic!("Expected array type declaration body");
+            }
+        } else {
+            panic!("Expected type declaration");
+        }
+    }
+
+    #[test]
+    fn let_member_access_target_parses() {
+        let result = parse_str_one("let (Eq int).eq = prim_int_eq", Some(&stdlib())).unwrap();
+        if let Ast::Let { target, .. } = result {
+            assert!(matches!(target, BindPattern::MemberAccess { .. }));
+        } else {
+            panic!("Expected let binding");
+        }
+    }
+
+    #[test]
+    fn qualified_function_name_parses() {
+        let result = parse_str_one(
+            "fn (Eq List T).eq<T: Eq>(xs, ys) = list_eq_by(T.eq, xs, ys)",
+            Some(&stdlib()),
+        )
+        .unwrap();
+        if let Ast::FunctionDef { name, params, .. } = result {
+            assert!(name.contains(".eq"));
+            assert_eq!(params.len(), 2);
+        } else {
+            panic!("Expected function definition");
         }
     }
 

--- a/lentoc/lib/src/type_checker/checked_ast.rs
+++ b/lentoc/lib/src/type_checker/checked_ast.rs
@@ -15,6 +15,21 @@ pub struct Effect {
     pub params: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArrayLenAst {
+    Known(usize),
+    Symbol(String),
+}
+
+impl ArrayLenAst {
+    pub fn print_expr(&self) -> String {
+        match self {
+            ArrayLenAst::Known(len) => len.to_string(),
+            ArrayLenAst::Symbol(name) => name.clone(),
+        }
+    }
+}
+
 impl Effect {
     pub fn print_expr(&self) -> String {
         if self.params.is_empty() {
@@ -58,7 +73,7 @@ pub enum TypeAst {
     },
     Array {
         elem: Box<TypeAst>,
-        len: usize,
+        len: ArrayLenAst,
         info: LineInfo,
     },
     List {
@@ -184,7 +199,7 @@ impl TypeAst {
                 }
             }
             TypeAst::Array { elem, len, .. } => {
-                format!("[{}; {}]", elem.print_expr(), len)
+                format!("[{}; {}]", elem.print_expr(), len.print_expr())
             }
             TypeAst::List { elem, .. } => {
                 format!("[{}]", elem.print_expr())
@@ -266,7 +281,7 @@ impl TypeAst {
                 }
             }
             TypeAst::Array { elem, len, .. } => {
-                format!("[{}; {}]", elem.pretty_print(), len)
+                format!("[{}; {}]", elem.pretty_print(), len.print_expr())
             }
             TypeAst::List { elem, .. } => {
                 format!("[{}]", elem.pretty_print())

--- a/lentoc/lib/src/type_checker/checker.rs
+++ b/lentoc/lib/src/type_checker/checker.rs
@@ -1,6 +1,6 @@
 use super::{
-    checked_ast::{CheckedAst, CheckedParam, TypeAst},
-    types::{std_types, FunctionType, GetType, Type, TypeTrait},
+    checked_ast::{ArrayLenAst, CheckedAst, CheckedParam, TypeAst},
+    types::{std_types, ArrayLen, FunctionType, GetType, Type, TypeTrait},
 };
 use crate::{
     interpreter::{
@@ -644,7 +644,13 @@ impl TypeChecker<'_> {
             }
             TypeAst::Array { elem, len, .. } => {
                 let elem_ty = self.check_type_expr(elem)?;
-                Type::Tuple(vec![elem_ty; *len])
+                Type::Array(
+                    Box::new(elem_ty),
+                    match len {
+                        ArrayLenAst::Known(len) => ArrayLen::Known(*len),
+                        ArrayLenAst::Symbol(name) => ArrayLen::Symbol(name.clone().into()),
+                    },
+                )
             }
             TypeAst::List { elem, .. } => {
                 let elem_ty = self.check_type_expr(elem)?;
@@ -938,8 +944,9 @@ impl TypeChecker<'_> {
         info: &LineInfo,
     ) -> TypeCheckerResult<CheckedAst> {
         match target {
-            BindPattern::Variable { name, .. } => {
-                if self.lookup_local_identifier(name).is_some() {
+            BindPattern::Variable { .. } | BindPattern::MemberAccess { .. } => {
+                let name = target.binding_name().expect("binding target name");
+                if self.lookup_local_identifier(&name).is_some() {
                     return Err(TypeError::new(
                         format!("{} is already defined", name.clone().yellow()),
                         info.clone(),
@@ -979,10 +986,7 @@ impl TypeChecker<'_> {
                 }
                 self.add_variable(name.clone(), ty.clone());
                 Ok(CheckedAst::Let {
-                    target: BindPattern::Variable {
-                        name: name.clone(),
-                        info: info.clone(),
-                    },
+                    target: target.clone(),
                     expr: Box::new(expr),
                     info: info.clone(),
                 })
@@ -1323,6 +1327,12 @@ impl TypeChecker<'_> {
                 self.add_variable(name.clone(), expr_ty.clone());
                 Ok(())
             }
+            BindPattern::MemberAccess { .. } => {
+                if let Some(name) = pattern.binding_name() {
+                    self.add_variable(name, expr_ty.clone());
+                }
+                Ok(())
+            }
             BindPattern::Tuple { elements, .. } => {
                 if let Type::Tuple(types) = expr_ty {
                     if elements.len() != types.len() {
@@ -1449,6 +1459,11 @@ fn binding_typed_names(pattern: &BindPattern, ty: &Type) -> HashSet<(String, Typ
         match pattern {
             BindPattern::Variable { name, .. } => {
                 names.insert((name.clone(), ty.clone()));
+            }
+            BindPattern::MemberAccess { .. } => {
+                if let Some(name) = pattern.binding_name() {
+                    names.insert((name, ty.clone()));
+                }
             }
             BindPattern::Tuple { elements, .. } => {
                 if let Type::Tuple(types) = ty {

--- a/lentoc/lib/src/type_checker/specialize.rs
+++ b/lentoc/lib/src/type_checker/specialize.rs
@@ -11,7 +11,7 @@ use crate::{
         },
         pattern::BindPattern,
     },
-    type_checker::checked_ast::{Effect, ParamAst, TypeAst},
+    type_checker::checked_ast::{ArrayLenAst, Effect, ParamAst, TypeAst},
     util::error::{BaseErrorExt, LineInfo},
 };
 use colorful::Colorful;
@@ -851,11 +851,10 @@ fn try_into_refinement(
     }))
 }
 
-fn array_len_from_ast(ast: Ast) -> Result<usize, ParseError> {
+fn array_len_from_ast(ast: Ast) -> Result<ArrayLenAst, ParseError> {
     let info = ast.info().clone();
-    // If the length is an identifier (e.g., a type parameter), use 0 as a placeholder
-    if matches!(&ast, Ast::Identifier { .. }) {
-        return Ok(0);
+    if let Ast::Identifier { name, .. } = ast.clone() {
+        return Ok(ArrayLenAst::Symbol(name));
     }
     let Ast::Literal { value, .. } = ast else {
         return Err(ParseError::new(
@@ -869,7 +868,7 @@ fn array_len_from_ast(ast: Ast) -> Result<usize, ParseError> {
             info,
         ));
     };
-    number_to_usize(&n).ok_or_else(|| {
+    number_to_usize(&n).map(ArrayLenAst::Known).ok_or_else(|| {
         ParseError::new(
             "Expected array length to be a non-negative integer".to_string(),
             info,

--- a/lentoc/lib/src/type_checker/specialize.rs
+++ b/lentoc/lib/src/type_checker/specialize.rs
@@ -609,7 +609,8 @@ pub fn is_type_expr(expr: &Ast, types: &HashSet<String>) -> bool {
         }
         Ast::List { exprs, .. } if exprs.len() == 1 => is_type_expr(&exprs[0], types),
         Ast::Array { elem, len, .. } => {
-            is_type_expr(elem, types) && matches!(**len, Ast::Literal { .. })
+            is_type_expr(elem, types)
+                && (matches!(**len, Ast::Literal { .. }) || matches!(**len, Ast::Identifier { .. }))
         }
         Ast::Literal { .. } => true,
         Ast::FunctionCall { expr, arg, .. } => {
@@ -805,11 +806,13 @@ fn try_into_refinement(
     fields: &[(RecordKey, Ast)],
     info: &LineInfo,
 ) -> Result<Option<TypeAst>, ParseError> {
-    if fields.len() != 1 {
+    if fields.is_empty() {
         return Ok(None);
     }
-    let (binder, field_ty) = &fields[0];
-    let Ast::Binary { lhs, op, rhs, .. } = field_ty else {
+    // Check if the last field has a `|` refinement
+    let last_idx = fields.len() - 1;
+    let (last_binder, last_field_ty) = &fields[last_idx];
+    let Ast::Binary { lhs, op, rhs, .. } = last_field_ty else {
         return Ok(None);
     };
     if op.symbol != SUM_TYPE_SYM {
@@ -821,9 +824,27 @@ fn try_into_refinement(
         return Ok(None);
     }
 
-    let base = into_type_ast((**lhs).clone())?;
+    // Build base type: convert all fields (splitting the last field's `|` part)
+    let mut base_fields: Vec<(RecordKey, TypeAst)> = Vec::new();
+    for (i, (key, field_ast)) in fields.iter().enumerate() {
+        if i == last_idx {
+            base_fields.push((key.clone(), into_type_ast((**lhs).clone())?));
+        } else {
+            base_fields.push((key.clone(), into_type_ast(field_ast.clone())?));
+        }
+    }
+
+    let base = if base_fields.len() == 1 {
+        base_fields.into_iter().next().unwrap().1
+    } else {
+        TypeAst::Record {
+            fields: base_fields,
+            info: info.clone(),
+        }
+    };
+
     Ok(Some(TypeAst::Refinement {
-        binder: binder.clone(),
+        binder: last_binder.clone(),
         base: Box::new(base),
         predicate: Box::new((**rhs).clone()),
         info: info.clone(),
@@ -832,6 +853,10 @@ fn try_into_refinement(
 
 fn array_len_from_ast(ast: Ast) -> Result<usize, ParseError> {
     let info = ast.info().clone();
+    // If the length is an identifier (e.g., a type parameter), use 0 as a placeholder
+    if matches!(&ast, Ast::Identifier { .. }) {
+        return Ok(0);
+    }
     let Ast::Literal { value, .. } = ast else {
         return Err(ParseError::new(
             "Expected array length to be an integer literal".to_string(),

--- a/lentoc/lib/src/type_checker/tests.rs
+++ b/lentoc/lib/src/type_checker/tests.rs
@@ -167,6 +167,12 @@ mod tests {
     }
 
     #[test]
+    fn symbolic_array_len_type_is_preserved_in_checker() {
+        let result = check_str_one("type Vec(n: int, A: Type) = [A; n]", Some(&stdlib())).unwrap();
+        assert!(matches!(result, CheckedAst::TypeDecl { .. }));
+    }
+
+    #[test]
     fn checked_list_type_decl() {
         let result = check_str_one("type Foo = [int]", Some(&stdlib())).unwrap();
         assert!(matches!(result, CheckedAst::TypeDecl { .. }));

--- a/lentoc/lib/src/type_checker/types.rs
+++ b/lentoc/lib/src/type_checker/types.rs
@@ -194,6 +194,21 @@ impl TypeTrait for FunctionType {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum ArrayLen {
+    Known(usize),
+    Symbol(Str),
+}
+
+impl ArrayLen {
+    pub fn pretty_print(&self) -> String {
+        match self {
+            ArrayLen::Known(len) => len.to_string(),
+            ArrayLen::Symbol(name) => name.to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Type {
     /// Placeholder for unknown types during type inference.
     /// Used when the type is not yet determined.
@@ -230,6 +245,9 @@ pub enum Type {
     /// ! There must be at least one element in the tuple.
     /// A tuple type is a product type.
     Tuple(Vec<Type>),
+
+    /// A fixed-size array type.
+    Array(Box<Type>, ArrayLen),
 
     /// A list type.
     /// The first argument is the type of the elements in the list.
@@ -327,6 +345,7 @@ impl TypeTrait for Type {
                     TypeJudgeResult::fail()
                 }
             }
+            (Type::Array(t1, l1), Type::Array(t2, l2)) => t1.subtype(t2).and((l1 == l2).into()),
             (Type::List(t1), Type::List(t2)) => t1.subtype(t2),
             (Type::Record(fields1), Type::Record(fields2)) => {
                 if fields1.len() == fields2.len() {
@@ -391,6 +410,7 @@ impl TypeTrait for Type {
                 Type::Function(Box::new(ty.simplify()))
             }
             Type::Tuple(types) => Type::Tuple(types.into_iter().map(Type::simplify).collect()),
+            Type::Array(t, len) => Type::Array(Box::new(t.simplify()), len),
             Type::List(t) => Type::List(Box::new(t.simplify())),
             Type::Map(key, value) => {
                 Type::Map(Box::new(key.simplify()), Box::new(value.simplify()))
@@ -445,6 +465,7 @@ impl TypeTrait for Type {
                     .map(|t| t.specialize(judgements, changed))
                     .collect(),
             ),
+            Type::Array(t, len) => Type::Array(Box::new(t.specialize(judgements, changed)), len.clone()),
             Type::List(t) => Type::List(Box::new(t.specialize(judgements, changed))),
             Type::Map(key, value) => Type::Map(
                 Box::new(key.specialize(judgements, changed)),
@@ -495,6 +516,7 @@ impl Display for Type {
                 }
                 write!(f, ")")
             }
+            Type::Array(t, len) => write!(f, "[{}; {}]", t, len.pretty_print()),
             Type::List(t) => write!(f, "[{}]", t),
             Type::Map(key, value) => write!(f, "Map({}, {})", key, value),
             Type::Record(fields) => {
@@ -567,6 +589,7 @@ impl Type {
                     result
                 }
             }
+            Type::Array(t, len) => format!("[{}; {}]", t.pretty_print(), len.pretty_print()),
             Type::List(t) => format!("[{}]", t.pretty_print()),
             Type::Map(key, value) => {
                 format!("Map({}, {})", key.pretty_print(), value.pretty_print())
@@ -653,6 +676,7 @@ impl Type {
                     result
                 }
             }
+            Type::Array(t, len) => format!("[{}; {}]", t.pretty_print_color(), len.pretty_print()),
             Type::List(t) => format!("[{}]", t.pretty_print_color()),
             Type::Map(key, value) => {
                 format!(


### PR DESCRIPTION
## Summary
- make peek_token_not non-consuming again and add regression coverage for lookahead with skip > 0
- extend parser support for typed type parameters, type constraints, &&, qualified function names, and member-access let targets
- preserve array lengths and member-access targets structurally through parsing and type checking by adding symbolic array lengths, Type::Array, and BindPattern::MemberAccess
- update CONTRIBUTING to target main

## Verification
- cargo build
- cargo run -- .\\examples\\basic\\types.lt
- cargo test -p lentoc_lib lexer::tests::tests::peek_token_not_is_non_consuming_with_skip -- --exact
- cargo test -p lentoc_lib parser::tests::tests::let_member_access_target_parses -- --exact
- cargo test -p lentoc_lib parser::tests::tests::qualified_function_name_parses -- --exact
- cargo test -p lentoc_lib parser::tests::tests::type_decl_static_vec_symbolic_len -- --exact
- cargo test -p lentoc_lib type_checker::tests::tests::symbolic_array_len_type_is_preserved_in_checker -- --exact

## Notes
- cargo run -- .\\examples\\basic\\types.lt now reaches the known forward-reference type error on Year; parsing no longer fails earlier.
