### PR TITLE
Hide placeholder CLI commands

### DIFF
--- a/lentoc/src/args.rs
+++ b/lentoc/src/args.rs
@@ -19,16 +19,8 @@ const MASCOT: &str = r#"
 "#;
 
 pub mod lento_command {
-    pub const BUILD: &str = "build";
-    pub const COMPILE: &str = "compile";
-    pub const DOC: &str = "doc";
     pub const EVAL: &str = "eval";
-    pub const FMT: &str = "fmt";
-    pub const LINT: &str = "lint";
     pub const REPL: &str = "repl";
-    pub const RUN: &str = "run";
-    pub const NEW: &str = "new";
-    pub const TEST: &str = "test";
 }
 
 pub fn lento_args() -> Command {
@@ -57,52 +49,12 @@ pub fn lento_args() -> Command {
     let examples = format!(
         "{EXAMPLES}
   {LT} file1.lt file2.lt              Interpret file1.lt and file2.lt in order
-  {LT} {C} file1.lt                     Compile file1.lt to a standalone executable
-  {LT} {COMP} --target js file1.lt   Cross compile file1.lt to JavaScript
   {LT} {EVAL} \"1 + 1\"                      Evaluate the expression 1 + 1
   {LT} {REPL}                              Start the REPL",
         EXAMPLES = "Examples:".bold().underlined(),
         LT = "lt".bold(),
         EVAL = "e".bold(),
-        REPL = "r".bold(),
-        COMP = "compile".bold(),
-        C = "c".bold()
-    );
-
-    let compile_targets = format!(
-        "{COMPILE_TARG}
-  {EXE}         Native standalone executable binary
-  {DLL}         Dynamically linked library/shared object
-  {ASM}         x86 assembly (Intel syntax/AT&T syntax)
-  {LLVM}        LLVM IR assembly (text)
-  {LLBC}     LLVM bitcode (LLVM IR binary)
-  {JS}          JavaScript (Web)
-  {NODE}        JavaScript (Node.js)
-  {WASM}        WebAssembly",
-        COMPILE_TARG = "Compile targets:".bold().underlined(),
-        EXE = "exe".bold(),
-        DLL = "dll".bold(),
-        ASM = "asm".bold(),
-        LLVM = "llvm".bold(),
-        LLBC = "llvm-bc".bold(),
-        JS = "js".bold(),
-        NODE = "node".bold(),
-        WASM = "wasm".bold()
-    );
-
-    let doc_targets = format!(
-        "{DOC_TARG}
-  {HTML}        HTML documentation
-  {MD}          Markdown documentation
-  {LAT}       LaTeX documentation
-  {PDF}         PDF documentation
-  {DOCX}        DOCX documentation",
-        DOC_TARG = "Documentation targets:".bold().underlined(),
-        HTML = "html".bold(),
-        MD = "md".bold(),
-        LAT = "latex".bold(),
-        PDF = "pdf".bold(),
-        DOCX = "docx".bold()
+        REPL = "r".bold()
     );
 
     // Current year
@@ -130,49 +82,6 @@ pub fn lento_args() -> Command {
     // ])
     // .subcommand_help_heading("\x1B[38;5;6mCommands\x1B[0m: ")
     .subcommand(
-        Command::new(lento_command::BUILD)
-        .alias("b")
-        .about("Build project")
-        .long_about("Builds a project to a standalone executable, a dynamically linked library,\nor cross compile to a target language or platform.")
-        .version("1.0")
-        .override_usage(format!("{} {}", "lt build".bold(), "(options)".dim()))
-        .args([
-            arg!(-r --release "Builds the project in release mode"),
-            arg!(-t --target <target> "Overrides the target to build for specified in the project file"),
-            debug_arg.clone(),
-        ])
-        .after_help(compile_targets.clone())
-    )
-    .subcommand(
-        Command::new(lento_command::COMPILE)
-        .alias("c")
-        .about("Compile file")
-        .long_about("Compiles a file to a standalone executable, a dynamically linked library,\nor cross compile to a target language or platform.")
-        .version("1.0")
-        .override_usage(format!("{} {}", "lt compile".bold(), "(options) [file]".dim()))
-        .args([
-            arg!(<file> "Sets the input file(s) to use"),
-            arg!(-t --target <target> "Sets the target arch triplet to compile for"),
-            arg!(-o --output <output> "Sets the output file to use").value_name("testing"),
-            debug_arg.clone(),
-        ])
-        .after_help(compile_targets.clone())
-    )
-    .subcommand(
-    Command::new(lento_command::DOC)
-        .alias("d")
-        .about("Generate documentation")
-        .long_about("Generates documentation for a project or a file.\nSupports Markdown, HTML, and LaTeX.")
-        .version("1.0")
-        .override_usage(format!("{} {}", "lt doc".bold(), "(options) (file)".dim()))
-        .args([
-            arg!([file] "Sets the input file to use (default: main.lt file)").default_value("main.lt"),
-            arg!(-o --output <output> "Sets the output file to use"),
-            debug_arg.clone(),
-        ])
-        .after_help(doc_targets)
-    )
-    .subcommand(
         Command::new(lento_command::EVAL)
         .alias("e")
         .about("Evaluate an expression")
@@ -181,47 +90,6 @@ pub fn lento_args() -> Command {
         .override_usage(format!("{} {}", "lt eval".bold(), "(options) [expr]".dim()))
         .args([
             arg!(<expr> "Sets the expression to evaluate"),
-            debug_arg.clone(),
-        ])
-    )
-    .subcommand(
-        Command::new(lento_command::FMT)
-        .alias("f")
-        .about("Format a file or project")
-        .long_about("Formats a file or a all file in the current project.\nThis command is useful for keeping code consistent and readable.")
-        .version("1.0")
-        .override_usage(format!("{} {}", "lt fmt".bold(), "(options) (file)".dim()))
-        .args([
-            arg!([file] "Sets the input file to use (default: all files in the current directory)"),
-            debug_arg.clone(),
-        ])
-    )
-    .subcommand(
-        Command::new(lento_command::LINT)
-        .alias("l")
-        .about("Lints one or more file")
-        .long_about("Lints one or more file and prints any warnings or errors.\nPassing no file will lint all files in the current directory.")
-        .version("1.0")
-        .override_usage(format!("{} {}", "lt lint".bold(), "(options) (file)".dim()))
-        .args([
-            arg!([file] "Sets the input file to use (default: all files in the current directory)"),
-            debug_arg.clone(),
-        ])
-    )
-    .subcommand(
-        Command::new(lento_command::NEW)
-        .alias("n")
-        .about("Create a new project")
-        .long_about("Creates a new project with the given name.\nUse the --template option to specify a template to use.\nUse the --license option to specify a license to use.\nUse the --author option to specify the author of the project.\nUse the --description option to specify a description of the project.\nUse the --git option to initialize a git repository.")
-        .version("1.0")
-        .override_usage(format!("{} {}", "lt new".bold(), "(options) [name]".dim()))
-        .args([
-            arg!([name] "Sets the name of the project").required(true),
-            arg!(-l --lib "Creates a library project").conflicts_with("bin"),
-			arg!(-b --bin "Creates a binary project").conflicts_with("lib"),
-            arg!(-t --template [template] "Sets the template to use"),
-            arg!(-a --author [author] "Sets the author to use"),
-            arg!(-d --description [description] "Sets the description to use"),
             debug_arg.clone(),
         ])
     )
@@ -236,29 +104,6 @@ pub fn lento_args() -> Command {
 			arg!(-t --types "Print the types of values"),
             debug_arg.clone(),
 		])
-    )
-    .subcommand(
-        Command::new(lento_command::RUN)
-        .about("Run project")
-        .long_about("Runs a project in debug mode, which means that the program will be compiled and executed.\nUse this command for quick testing and debugging.")
-        .version("1.0")
-        .override_usage(format!("{} {}", "lt run".bold(), "(options)".dim()))
-        .args([
-			arg!([task] "Sets the project task to run").default_value("start"),
-            debug_arg.clone(),
-        ])
-    )
-    .subcommand(
-        Command::new(lento_command::TEST)
-        .alias("t")
-        .about("Run unit tests")
-        .long_about("Runs unit tests in the current project.\nPassing no file will run all tests in the current directory.")
-        .version("1.0")
-        .override_usage(format!("{} {}", "lt test".bold(), "(options) (file)".dim()))
-        .args([
-            arg!([file] "Sets the input file to use (default: all files in the current directory)"),
-            debug_arg.clone(),
-        ])
     )
     .after_long_help(format!("{examples}\n\n{copy}"))
     .arg_required_else_help(true)

--- a/lentoc/src/main.rs
+++ b/lentoc/src/main.rs
@@ -21,18 +21,8 @@ fn main() {
     }
 
     match args.subcommand() {
-        Some((lento_command::BUILD, _)) => println!("The build command is not yet implemented!"),
-        Some((lento_command::COMPILE, _)) => {
-            println!("The compile command is not yet implemented!")
-        }
-        Some((lento_command::DOC, _)) => println!("The doc command is not yet implemented!"),
         Some((lento_command::EVAL, args)) => handle_command_eval(args, &mut arg_parser),
-        Some((lento_command::FMT, _)) => println!("The fmt command is not yet implemented!"),
-        Some((lento_command::LINT, _)) => println!("The lint command is not yet implemented!"),
         Some((lento_command::REPL, args)) => handle_command_repl(args, &mut arg_parser),
-        Some((lento_command::RUN, _)) => println!("The run command is not yet implemented!"),
-        Some((lento_command::NEW, _)) => println!("The new command is not yet implemented!"),
-        Some((lento_command::TEST, _)) => println!("The test command is not yet implemented!"),
         _ => match args.get_one::<String>("file") {
             Some(raw_file) => handle_command_file(raw_file),
             _ => {


### PR DESCRIPTION
## Summary
- Hide unimplemented CLI subcommands from help and dispatch.
- Keep working file interpretation, eval, and repl flows visible.

## Validation
- cargo test -p lentoc
- cargo run -q -p lentoc -- --help

Note: cargo fmt --check still fails on pre-existing formatting differences outside these CLI files.