### PR TITLE
Fix interpreter let syntax tests

### DIFF
--- a/lentoc/lib/src/interpreter/tests.rs
+++ b/lentoc/lib/src/interpreter/tests.rs
@@ -222,13 +222,12 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "legacy numeric coercion behavior under parser migration"]
     fn module_assign_add() {
         let module = parse_str_all(
             r#"
-			x = 1;
-			y = 2;
-			z = x + y;
+			let x = 1;
+			let y = 2;
+			let z = x + y;
 		"#,
             Some(&stdlib()),
         )
@@ -261,7 +260,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "typed u8 operator resolution still in migration"]
     fn function_decl_typed_signature_oneline() {
         let module = parse_str_all(
             "fn add(x: u8, y: u8, z: u8) -> u8 = x + y + z;",
@@ -269,6 +267,7 @@ mod tests {
         )
         .expect("Failed to parse module");
         let mut checker = TypeChecker::default();
+        stdlib().init_type_checker(&mut checker);
         let module = checker
             .check_top_exprs(&module)
             .expect("Failed to type check module");

--- a/lentoc/lib/src/type_checker/checker.rs
+++ b/lentoc/lib/src/type_checker/checker.rs
@@ -341,34 +341,28 @@ impl TypeChecker<'_> {
                 let BindPattern::Variable { name, .. } = target else {
                     continue;
                 };
-                match expr.borrow() {
-                    Ast::Lambda {
-                        param, body, info, ..
-                    } => {
-                        let checked_param = self.check_param(param)?;
-                        let checked = self.check_lambda(checked_param.clone(), body, info)?;
-                        let return_type = if let CheckedAst::Lambda { return_type, .. } = &checked {
-                            return_type.clone()
-                        } else {
-                            checked.get_type().clone()
-                        };
-                        let variation = FunctionType {
-                            param: checked_param,
-                            return_type,
-                        };
-                        log::debug!(
-                            "Adding function {} with variation {}",
-                            name.clone().yellow(),
-                            variation.pretty_print()
-                        );
-                        self.env.add_function(name.clone(), variation);
-                    }
-                    _ => {
-                        let checked = self.check_expr(expr)?;
-                        self.env
-                            .add_variable(name.clone(), checked.get_type().clone());
-                    }
-                }
+                let Ast::Lambda {
+                    param, body, info, ..
+                } = expr.borrow() else {
+                    continue;
+                };
+                let checked_param = self.check_param(param)?;
+                let checked = self.check_lambda(checked_param.clone(), body, info)?;
+                let return_type = if let CheckedAst::Lambda { return_type, .. } = &checked {
+                    return_type.clone()
+                } else {
+                    checked.get_type().clone()
+                };
+                let variation = FunctionType {
+                    param: checked_param,
+                    return_type,
+                };
+                log::debug!(
+                    "Adding function {} with variation {}",
+                    name.clone().yellow(),
+                    variation.pretty_print()
+                );
+                self.env.add_function(name.clone(), variation);
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary
- enable the two ignored interpreter tests
- update the legacy assignment fixture to the current let syntax
- keep ordinary let bindings out of scan-forward pre-registration while preserving let-bound lambda registration

## Tests
- cargo test